### PR TITLE
Add Resilio Sync resilience with scheduled restarts

### DIFF
--- a/bin/deploy-do
+++ b/bin/deploy-do
@@ -225,6 +225,10 @@ class DigitalOceanDeploy {
     printInfo('Installing logrotate configuration...');
     this.sshCmd(`sudo cp ${this.deployPath}/config/logrotate-today /etc/logrotate.d/today && sudo chmod 644 /etc/logrotate.d/today && echo "✓ Logrotate configured"`);
 
+    // Update Resilio Sync service config
+    printInfo('Updating Resilio Sync service configuration...');
+    this.sshCmd(`sudo cp ${this.deployPath}/config/resilio-sync.service /etc/systemd/system/resilio-sync.service && sudo systemctl daemon-reload && echo "✓ Resilio Sync service updated"`);
+
     // Setup WAL checkpoint cron
     printInfo('Setting up SQLite WAL checkpoint cron job...');
     this.sshScript(`

--- a/config/resilio-sync.service
+++ b/config/resilio-sync.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Resilio Sync
+Documentation=https://help.resilio.com
+After=network.target
+
+[Service]
+Type=simple
+User=rslsync
+Group=rslsync
+RuntimeDirectory=resilio-sync
+RuntimeDirectoryMode=0755
+ExecStartPre=/bin/mkdir -p /var/run/resilio-sync
+ExecStartPre=/bin/chown rslsync:rslsync /var/run/resilio-sync
+ExecStart=/usr/bin/rslsync --config /etc/resilio-sync/config.json --nodaemon
+Restart=always
+RestartSec=5
+# Restart daily as backup if scheduler isn't running
+RuntimeMaxSec=86400
+# Memory limit - restart if exceeds 512MB
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -95,6 +95,11 @@ const jobs = [
         description: 'Droplet maintenance (cleanup logs, check processes)'
     },
     {
+        schedule: '0 */2 * * *', // Every 2 hours EST
+        command: 'systemctl restart resilio-sync || true',
+        description: 'Restart Resilio Sync to prevent stale connections'
+    },
+    {
         schedule: '*/15 * * * *', // Every 15 minutes
         command: 'bin/droplet-monitor || true',
         description: 'Monitor droplet health'


### PR DESCRIPTION
## Summary
- Add systemd service config with 24-hour RuntimeMaxSec failsafe and 512MB memory limit
- Schedule restarts every 2 hours via scheduler to prevent stale connections
- Deploy script now installs the service config during deploys

## Test plan
- [ ] Deploy to droplet with `bin/deploy-do deploy`
- [ ] Verify Resilio Sync service is updated: `bin/deploy-do exec "systemctl cat resilio-sync"`
- [ ] Confirm scheduler shows new job in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)