### PR TITLE
Fix non-interactive mode on macOS

### DIFF
--- a/bin/today
+++ b/bin/today
@@ -530,11 +530,20 @@ ${contextSection}`;
 
     if (nonInteractive) {
       console.log('🤖 Running in non-interactive mode...');
-      try {
-        spawnSync('timeout', ['600', 'claude', '--model', model, '--print', '--dangerously-skip-permissions', prompt], { stdio: 'inherit' });
-      } catch (e) {
-        console.error(`ERROR: Command timed out or failed after 10 minutes: ${e.message}`);
+      const result = spawnSync('claude', ['--model', model, '--print', '--dangerously-skip-permissions', prompt], {
+        stdio: 'inherit',
+        timeout: 600000 // 10 minutes in milliseconds
+      });
+      if (result.error) {
+        if (result.error.code === 'ETIMEDOUT') {
+          console.error('ERROR: Command timed out after 10 minutes');
+        } else {
+          console.error(`ERROR: ${result.error.message}`);
+        }
         process.exit(1);
+      }
+      if (result.status !== 0) {
+        process.exit(result.status || 1);
       }
     } else if (directRequest) {
       console.log('🤖 Starting session...');
@@ -545,7 +554,7 @@ ${contextSection}`;
     }
 
     console.log('\n' + '━'.repeat(50));
-    console.log('✅ Session ended\n');
+    console.log('✅ Session ended');
     console.log('━'.repeat(50) + '\n');
   }
 


### PR DESCRIPTION
## Summary
- Fix `--non-interactive` mode failing silently on macOS
- The `timeout` command doesn't exist on macOS by default
- Use Node's built-in `spawnSync` timeout option instead
- Properly check result for errors and non-zero exit codes

## Test plan
- [x] All tests pass
- [ ] Test `bin/today now --no-sync --non-interactive` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)