### PR TITLE
Auto-stash local changes during update check

### DIFF
--- a/bin/today
+++ b/bin/today
@@ -163,10 +163,40 @@ async function checkForUpdates(execSync, readline) {
     if (answer.toLowerCase() !== 'n' && answer.toLowerCase() !== 'no') {
       console.log('');
       console.log('Updating...');
-      execSync('git pull origin main', { cwd: projectRoot, stdio: 'inherit' });
-      console.log('');
-      console.log('✅ Updated! Please restart bin/today to use the new version.');
-      process.exit(0);
+
+      // Check for local changes that would block the pull
+      const status = execSync('git status --porcelain', { cwd: projectRoot, encoding: 'utf8' }).trim();
+      const hasLocalChanges = status.length > 0;
+
+      if (hasLocalChanges) {
+        console.log('Stashing local changes...');
+        execSync('git stash --include-untracked', { cwd: projectRoot, stdio: 'pipe' });
+      }
+
+      try {
+        execSync('git pull origin main', { cwd: projectRoot, stdio: 'inherit' });
+
+        if (hasLocalChanges) {
+          console.log('Restoring local changes...');
+          try {
+            execSync('git stash pop', { cwd: projectRoot, stdio: 'pipe' });
+          } catch {
+            console.log('⚠️  Could not auto-restore changes. Run: git stash pop');
+          }
+        }
+
+        console.log('');
+        console.log('✅ Updated! Please restart bin/today to use the new version.');
+        process.exit(0);
+      } catch (pullError) {
+        // Restore stashed changes if pull failed
+        if (hasLocalChanges) {
+          try {
+            execSync('git stash pop', { cwd: projectRoot, stdio: 'pipe' });
+          } catch { /* ignore */ }
+        }
+        console.error('❌ Update failed. Please run: git pull origin main');
+      }
     }
 
     console.log('');


### PR DESCRIPTION
## Summary
- Auto-stash local changes before pulling updates
- Restore changes after successful pull
- Show clear error message if pull fails
- Fixes issue where package-lock.json changes block updates

## Test plan
- [x] Tested with local changes present
- [ ] Test on macOS with package-lock.json modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)