### PR TITLE
Update all major dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@ai-sdk/anthropic": "^3.0.1",
         "@ai-sdk/google": "^3.0.1",
         "@ai-sdk/openai": "^3.0.1",
-        "@anthropic-ai/sdk": "^0.71.2",
-        "@clack/prompts": "^0.11.0",
+        "@anthropic-ai/sdk": "^0.72.1",
+        "@clack/prompts": "^1.0.0",
         "@date-fns/tz": "^1.4.1",
         "@dotenvx/dotenvx": "^1.51.1",
         "@inkjs/ui": "^2.0.0",
@@ -32,7 +32,7 @@
         "enquirer": "^2.4.1",
         "express": "^5.2.1",
         "express-session": "^1.18.2",
-        "googleapis": "^167.0.0",
+        "googleapis": "^171.3.0",
         "highlight.js": "^11.11.1",
         "htm": "^3.1.1",
         "imapflow": "^1.1.1",
@@ -45,7 +45,7 @@
         "moment": "^2.30.1",
         "node-cron": "^4.2.1",
         "node-fetch": "^3.3.2",
-        "ollama-ai-provider-v2": "^1.5.5",
+        "ollama-ai-provider-v2": "^3.0.3",
         "puppeteer": "^24.36.0",
         "react": "^19.2.3",
         "smol-toml": "^1.5.2",
@@ -60,7 +60,7 @@
         "@types/jest": "^30.0.0",
         "jest": "^30.2.0",
         "lefthook": "^2.0.9",
-        "markdownlint-cli2": "^0.19.1"
+        "markdownlint-cli2": "^0.20.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.34",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.34.tgz",
-      "integrity": "sha512-ZS1dWai5DINQOv3bpNi3ua9+yt3jnRaux3CwEr/ai9qETp6T+2wcpZyw+0jUHo1He/Lznw//AQh4zhdwHnTWrg==",
+      "version": "3.0.35",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.35.tgz",
+      "integrity": "sha512-9aRTVM1P1u4yUIjBpco/WCF1WXr/DgWKuDYgLLHdENS8kiEuxDOPJuGbc/6+7EwQ6ZqSh0UOgeqvHfGJfU23Qg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.7",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.71.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
-      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "version": "0.72.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.72.1.tgz",
+      "integrity": "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -697,9 +697,9 @@
       "license": "MIT"
     },
     "node_modules/@clack/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -707,12 +707,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
-      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0.tgz",
+      "integrity": "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "0.5.0",
+        "@clack/core": "1.0.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }
@@ -1896,9 +1896,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2539,12 +2539,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.71",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.71.tgz",
-      "integrity": "sha512-33/Qq0BhEG+SabYeE7ZlLL3DCubUQo04C8E9UdEHqh2DJuGdtxMXG/TSMkO2uF+ZmlGJpD4UY5Wij9/qal298w==",
+      "version": "6.0.72",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.72.tgz",
+      "integrity": "sha512-D3TzDX6LzYL8qwi1A0rLnmuUexqDcCu4LSg77hcDHsqNRkaGspGItkz1U3RnN3ojv31XQYI9VmoWpkj44uvIUA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.34",
+        "@ai-sdk/gateway": "3.0.35",
         "@ai-sdk/provider": "3.0.7",
         "@ai-sdk/provider-utils": "4.0.13",
         "@opentelemetry/api": "1.9.0"
@@ -3549,13 +3549,12 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.0.tgz",
-      "integrity": "sha512-IdGNojX6S04+wgJOALzvkkIyLelhEGqI8xSctwiYJJGSi9T2eBjwAQW2UjBD/mCXv/rUkNlH2+h7jz+58vT74A==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.1.tgz",
+      "integrity": "sha512-zB9MpoPd7VJwjowQqiW3FKOvQwffFMjQ8Iejp5ZW+sJaKLRhZX1sTxzl3Zt22TDB4zP0OOqs8lRoY7eAW5geyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
-        "puppeteer": "^24.36.0",
         "zod": "^3.24.1"
       },
       "peerDependencies": {
@@ -5447,9 +5446,9 @@
       }
     },
     "node_modules/googleapis": {
-      "version": "167.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-167.0.0.tgz",
-      "integrity": "sha512-8Xqeki6K9u9jh6rGRA/OywRMXg8yXuv4ZLwSSuMBB3Ze1pErbR/iv00UmVtcrP2LcSW2Fqi+LUJ7WgFMDoxd7Q==",
+      "version": "171.3.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.3.0.tgz",
+      "integrity": "sha512-koedQak0LZjogRvb1fD0eWXtZ0K0swJ1BkWGVvpvOA0JKH5q1EUpzHhb/kyCXTBiLMKsara6tueao3kK9jJpBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.2.0",
@@ -7980,9 +7979,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.39.0.tgz",
-      "integrity": "sha512-Xt/oY7bAiHwukL1iru2np5LIkhwD19Y7frlsiDILK62v3jucXCD6JXlZlwMG12HZOR+roHIVuJZrfCkOhp6k3g==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7993,7 +7992,8 @@
         "micromark-extension-gfm-footnote": "2.1.0",
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
-        "micromark-util-types": "2.0.2"
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
       },
       "engines": {
         "node": ">=20"
@@ -8003,9 +8003,9 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.19.1.tgz",
-      "integrity": "sha512-p3JTemJJbkiMjXEMiFwgm0v6ym5g8K+b2oDny+6xdl300tUKySxvilJQLSea48C6OaYNmO30kH9KxpiAg5bWJw==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.20.0.tgz",
+      "integrity": "sha512-esPk+8Qvx/f0bzI7YelUeZp+jCtFOk3KjZ7s9iBQZ6HlymSXoTtWGiIRZP05/9Oy2ehIoIjenVwndxGtxOIJYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8013,7 +8013,7 @@
         "js-yaml": "4.1.1",
         "jsonc-parser": "3.3.1",
         "markdown-it": "14.1.0",
-        "markdownlint": "0.39.0",
+        "markdownlint": "0.40.0",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8"
       },
@@ -8038,6 +8038,52 @@
       },
       "peerDependencies": {
         "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/marked": {
@@ -9377,48 +9423,20 @@
       }
     },
     "node_modules/ollama-ai-provider-v2": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-1.5.5.tgz",
-      "integrity": "sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-3.0.3.tgz",
+      "integrity": "sha512-fdSYb81sU80Op/O4tH0eBUMfmc9wCRJBIBRdFZzIYUpEkI6+Qq/k+CWVSaMN/j02UnUTjJf8UIOlASRA3teRcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "^2.0.0",
-        "@ai-sdk/provider-utils": "^3.0.17"
+        "@ai-sdk/provider": "^3.0.5",
+        "@ai-sdk/provider-utils": "^4.0.10"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
+        "ai": "^5.0.0 || ^6.0.0",
         "zod": "^4.0.16"
-      }
-    },
-    "node_modules/ollama-ai-provider-v2/node_modules/@ai-sdk/provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ollama-ai-provider-v2/node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.20.tgz",
-      "integrity": "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.1",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -10057,17 +10075,17 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.37.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.0.tgz",
-      "integrity": "sha512-s1jHugVhPtQjiJE6wUyonj4VEGWF+mfRDASqPMPsXgKcjZX0GaznBmcT9nLQ7bBL90phuQUqO4jiV5vTecZg4g==",
+      "version": "24.37.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.1.tgz",
+      "integrity": "sha512-iugAcwjRIX6XsMS1dzWbjKKUcEE0ZmmRbV0T6RyTtXNSHyBdss0r9GYJ9eOjUZfOoWeKCIOAptogdHYoBbJDeA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.12.0",
-        "chromium-bidi": "13.1.0",
+        "chromium-bidi": "13.1.1",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1566079",
-        "puppeteer-core": "24.37.0",
+        "puppeteer-core": "24.37.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -10078,13 +10096,13 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.37.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.0.tgz",
-      "integrity": "sha512-WoCBK36cBlbaxwuvPWhOp2+lR6O6ynHdDuvD8rEIkxPOPpUoMXSJuyiOWhHtexJBCLaMCAJk33QdYambvQl+og==",
+      "version": "24.37.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.1.tgz",
+      "integrity": "sha512-ylRJReaA6kd/CrahdrxxnSZf5S2hf1QR0S39QeoS55fuBoOl4UggGPW94zheu9lmCokpRQpa7q8r98xYyiQl0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.12.0",
-        "chromium-bidi": "13.1.0",
+        "chromium-bidi": "13.1.1",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1566079",
         "typed-query-selector": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@ai-sdk/anthropic": "^3.0.1",
     "@ai-sdk/google": "^3.0.1",
     "@ai-sdk/openai": "^3.0.1",
-    "@anthropic-ai/sdk": "^0.71.2",
-    "@clack/prompts": "^0.11.0",
+    "@anthropic-ai/sdk": "^0.72.1",
+    "@clack/prompts": "^1.0.0",
     "@date-fns/tz": "^1.4.1",
     "@dotenvx/dotenvx": "^1.51.1",
     "@inkjs/ui": "^2.0.0",
@@ -40,7 +40,7 @@
     "enquirer": "^2.4.1",
     "express": "^5.2.1",
     "express-session": "^1.18.2",
-    "googleapis": "^167.0.0",
+    "googleapis": "^171.3.0",
     "highlight.js": "^11.11.1",
     "htm": "^3.1.1",
     "imapflow": "^1.1.1",
@@ -53,7 +53,7 @@
     "moment": "^2.30.1",
     "node-cron": "^4.2.1",
     "node-fetch": "^3.3.2",
-    "ollama-ai-provider-v2": "^1.5.5",
+    "ollama-ai-provider-v2": "^3.0.3",
     "puppeteer": "^24.36.0",
     "react": "^19.2.3",
     "smol-toml": "^1.5.2",
@@ -71,7 +71,7 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.2.0",
     "lefthook": "^2.0.9",
-    "markdownlint-cli2": "^0.19.1"
+    "markdownlint-cli2": "^0.20.0"
   },
   "overrides": {
     "nodemailer": "^7.0.11"


### PR DESCRIPTION
## Summary
- @anthropic-ai/sdk: 0.71.2 → 0.72.1
- @clack/prompts: 0.11.0 → 1.0.0 (first stable release)
- googleapis: 167.0.0 → 171.3.0
- ollama-ai-provider-v2: 1.5.5 → 3.0.3
- markdownlint-cli2: 0.19.1 → 0.20.0

## Test plan
- [x] All 355 tests passing locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)