### PR TITLE
feat(deploy): add git-sync as a vault sync option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,14 @@ bin/today --focus --non-interactive  # Automated preset run
 
 Many file-based plugins look for a "vault" directory and follow some [Obsidian](https://obsidian.md) conventions. The path to the vault can be configured, and defaults to `vault/` under Today's directory. Plugins automatically create their required directories inside the vault when first used.
 
-**Important:** The `vault/` directory is gitignored because it contains personal data. Initialize it as a separate repository or sync it with your preferred solution (Resilio Sync, Syncthing, iCloud, Obsidian, etc.). Plugins have permission to read and write from the vault. We *strongly suggest* you run `git init` within the vault and monitor its changes to make sure you're happy with any changes `today` makes.
+**Important:** The `vault/` directory is gitignored because it contains personal data. Initialize it as a separate repository or sync it with your preferred solution. Plugins have permission to read and write from the vault. We *strongly suggest* you run `git init` within the vault and monitor its changes to make sure you're happy with any changes `today` makes.
+
+For multi-device sync, Today supports two built-in options on remote deployments (see `bin/deploy <name> setup --git-sync` or `--resilio`):
+
+- **git-sync** (recommended): a systemd timer pulls/rebases/pushes the vault against its git remote every ~60s. No background daemon, no opaque state — conflicts surface as normal git rebase failures and get resolved on whichever peer introduced them. Requires the vault to be a git checkout with push credentials configured.
+- **Resilio Sync**: peer-to-peer sync via the Resilio daemon. Realtime and requires no git setup, but introduces a stateful daemon with its own sync metadata. Make sure `.git`, `.git.nosync`, and `node_modules` are in the share's IgnoreList before adding the folder — unignored git directories will flood the daemon.
+
+You can also use any external sync you already run (Syncthing, iCloud, Dropbox, etc.); those don't need integration with Today.
 
 ---
 

--- a/bin/git-sync
+++ b/bin/git-sync
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Sync /opt/today/vault with origin/main via git pull --rebase + push.
+# Designed to run from a systemd timer every ~60s. Exits non-zero on error
+# so systemd reports failure; the timer keeps firing regardless.
+
+set -o pipefail
+
+VAULT=/opt/today/vault
+LOG=/var/log/git-sync.log
+
+cd "$VAULT" || { echo "$(date -Iseconds) FATAL cannot cd to $VAULT" >>"$LOG"; exit 1; }
+
+log() { echo "$(date -Iseconds) $*" >>"$LOG"; }
+
+# Abort any in-progress rebase from a previous failure before trying again.
+GITDIR=$(git rev-parse --git-dir 2>/dev/null) || { log "FATAL not a git repo"; exit 1; }
+if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
+  log "WARN stale rebase state detected, aborting"
+  git rebase --abort 2>>"$LOG" || true
+fi
+
+# Pull first so we don't push over upstream changes.
+if ! git pull --rebase --autostash 2>>"$LOG"; then
+  log "ERROR pull failed"
+  # If the rebase left state behind, clean up so next run starts fresh.
+  if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
+    git rebase --abort 2>>"$LOG" || true
+  fi
+  exit 2
+fi
+
+# Push any local commits.
+if ! git push 2>>"$LOG"; then
+  log "ERROR push failed"
+  exit 3
+fi
+
+# Only log success if something actually changed, to keep the log quiet.
+# Not strictly necessary; we can refine later.
+exit 0

--- a/bin/git-sync-healthcheck
+++ b/bin/git-sync-healthcheck
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Vault git-sync health check.
+#
+# Verifies the git-sync.timer is firing successfully. If the last run failed,
+# or the last successful run was too long ago, surfaces a conflict/failure
+# marker in the vault so it's visible during normal use.
+#
+# Intended to run every 5 minutes via the Today scheduler.
+
+set -o pipefail
+
+UNIT=git-sync.service
+TIMER=git-sync.timer
+VAULT=/opt/today/vault
+MARKER="$VAULT/.sync-status.md"
+MAX_STALE_SECONDS=600  # 10 minutes — alert if no successful run in this window
+
+# Only check if the timer is enabled
+if ! systemctl is-enabled --quiet "$TIMER" 2>/dev/null; then
+  exit 0
+fi
+
+# Look at the last run result
+last_result=$(systemctl show "$UNIT" --property=Result --value 2>/dev/null)
+last_exit_status=$(systemctl show "$UNIT" --property=ExecMainStatus --value 2>/dev/null)
+last_exit_ts=$(systemctl show "$UNIT" --property=ExecMainExitTimestampMonotonic --value 2>/dev/null)
+
+# Compute seconds since last exit (monotonic clock)
+now_mono=$(awk '{print int($1 * 1000000)}' /proc/uptime)
+if [ -n "$last_exit_ts" ] && [ "$last_exit_ts" -gt 0 ] 2>/dev/null; then
+  elapsed=$(( (now_mono - last_exit_ts) / 1000000 ))
+else
+  elapsed=-1
+fi
+
+write_marker() {
+  local status="$1"
+  local detail="$2"
+  cat > "$MARKER" << EOF
+---
+tags: [sync, alert]
+updated: $(date -Iseconds)
+---
+# ⚠ Vault sync alert
+
+**Status:** $status
+**Last run result:** $last_result (exit $last_exit_status)
+**Last run:** ${elapsed}s ago
+**Detail:** $detail
+
+Investigate with:
+\`\`\`
+systemctl status $UNIT
+journalctl -u $UNIT --since '1 hour ago'
+tail -50 /var/log/git-sync.log
+\`\`\`
+
+Resolve conflicts on the peer where they were introduced, then delete this file.
+EOF
+}
+
+clear_marker() {
+  [ -f "$MARKER" ] && rm -f "$MARKER"
+}
+
+# Decide status
+if [ "$last_result" = "success" ] && [ "$last_exit_status" = "0" ]; then
+  if [ "$elapsed" -ge 0 ] && [ "$elapsed" -gt "$MAX_STALE_SECONDS" ]; then
+    write_marker "STALE" "Last success was ${elapsed}s ago; timer may be stopped or stuck."
+    exit 1
+  fi
+  clear_marker
+  exit 0
+fi
+
+if [ "$last_result" = "exit-code" ]; then
+  case "$last_exit_status" in
+    2) write_marker "PULL FAILED" "git pull --rebase failed — likely a conflict or network error." ;;
+    3) write_marker "PUSH FAILED" "git push failed — likely a non-fast-forward or auth error." ;;
+    *) write_marker "FAILED" "git-sync exited with status $last_exit_status." ;;
+  esac
+  exit 1
+fi
+
+# Unknown state — don't flap the marker
+exit 0

--- a/deploy/systemd/git-sync.service
+++ b/deploy/systemd/git-sync.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Vault git sync (pull/rebase/push)
+Documentation=https://github.com/jeffcovey/today
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/today/bin/git-sync
+User=root
+Nice=10

--- a/deploy/systemd/git-sync.timer
+++ b/deploy/systemd/git-sync.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodically sync the vault with its git remote
+
+[Timer]
+OnBootSec=30s
+OnUnitInactiveSec=55s
+RandomizedDelaySec=10s
+AccuracySec=5s
+Unit=git-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/src/deploy/commands/services.js
+++ b/src/deploy/commands/services.js
@@ -11,7 +11,8 @@ const SERVICES = [
   'vault-watcher',
   'vault-web',
   'inbox-api',
-  'resilio-sync'
+  'resilio-sync',
+  'git-sync.timer'
 ];
 
 export async function servicesCommand(server, args = []) {

--- a/src/deploy/commands/setup.js
+++ b/src/deploy/commands/setup.js
@@ -17,6 +17,12 @@ export async function setupCommand(server, args = []) {
   const skipConfirm = args.includes('--yes') || args.includes('-y');
   const withOllama = args.includes('--ollama');
   const withResilio = args.includes('--resilio');
+  const withGitSync = args.includes('--git-sync');
+
+  if (withResilio && withGitSync) {
+    printError('--resilio and --git-sync are mutually exclusive; pick one vault sync method.');
+    process.exit(1);
+  }
 
   if (!skipConfirm && process.stdin.isTTY) {
     console.log('');
@@ -31,6 +37,9 @@ export async function setupCommand(server, args = []) {
     }
     if (withResilio) {
       console.log('  • Install Resilio Sync for vault synchronization');
+    }
+    if (withGitSync) {
+      console.log('  • Install git-sync for vault synchronization via GitHub');
     }
     console.log('');
 
@@ -65,6 +74,11 @@ export async function setupCommand(server, args = []) {
     await server.setupResilioSync();
   }
 
+  // Optional: git-sync
+  if (withGitSync && typeof server.setupGitSync === 'function') {
+    await server.setupGitSync();
+  }
+
   // Optional: Ollama
   if (withOllama && typeof server.setupOllama === 'function') {
     await server.setupOllama();
@@ -75,8 +89,10 @@ export async function setupCommand(server, args = []) {
   console.log('Next steps:');
   console.log(`  1. bin/deploy ${server.name} secrets    # Upload encrypted secrets`);
   console.log(`  2. bin/deploy ${server.name}            # Deploy code`);
-  if (!withResilio) {
-    console.log(`  3. bin/deploy ${server.name} setup --resilio  # Optional: Setup vault sync`);
+  if (!withResilio && !withGitSync) {
+    console.log('  3. Pick a vault sync method:');
+    console.log(`       bin/deploy ${server.name} setup --git-sync   # Sync via GitHub (recommended)`);
+    console.log(`       bin/deploy ${server.name} setup --resilio    # Sync via Resilio Sync`);
   }
 }
 

--- a/src/deploy/providers/digitalocean.js
+++ b/src/deploy/providers/digitalocean.js
@@ -229,6 +229,68 @@ SERVICE
   }
 
   /**
+   * Install the git-based vault sync (systemd timer + shell script).
+   *
+   * Pulls/rebases/pushes /opt/today/vault against its git remote every 60s.
+   * Unit files live in deploy/systemd/ in the Today repo so they can be edited
+   * with the rest of the code; this method just inlines them over SSH.
+   *
+   * Assumes the deploy already placed bin/git-sync and bin/git-sync-healthcheck
+   * under ${this.deployPath}/bin/ (standard deploy does). Assumes the vault
+   * directory is already a git checkout with working credentials for push.
+   */
+  async setupGitSync() {
+    printInfo('Setting up git-sync...');
+
+    const repoRoot = path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..');
+    const serviceUnit = fs.readFileSync(
+      path.join(repoRoot, 'deploy', 'systemd', 'git-sync.service'),
+      'utf8'
+    );
+    const timerUnit = fs.readFileSync(
+      path.join(repoRoot, 'deploy', 'systemd', 'git-sync.timer'),
+      'utf8'
+    );
+
+    this.sshScript(`
+      set -e
+
+      if [ ! -x ${this.deployPath}/bin/git-sync ]; then
+        echo "✗ ${this.deployPath}/bin/git-sync not found — run 'bin/deploy ${this.name}' first"
+        exit 1
+      fi
+      if [ ! -d ${this.deployPath}/${this.remoteVaultPath}/.git ] && [ ! -f ${this.deployPath}/${this.remoteVaultPath}/.git ]; then
+        echo "✗ ${this.deployPath}/${this.remoteVaultPath} is not a git checkout"
+        echo "  Clone the vault repo there first, then re-run this setup."
+        exit 1
+      fi
+
+      touch /var/log/git-sync.log
+      chmod 644 /var/log/git-sync.log
+
+      cat > /etc/systemd/system/git-sync.service << 'SERVICE'
+${serviceUnit}SERVICE
+
+      cat > /etc/systemd/system/git-sync.timer << 'TIMER'
+${timerUnit}TIMER
+
+      systemctl daemon-reload
+      systemctl enable --now git-sync.timer
+
+      # Kick off an immediate run so the timer's first pull happens before 30s boot delay
+      systemctl start git-sync.service || true
+
+      echo ""
+      echo "✓ git-sync installed"
+      echo "  Timer: git-sync.timer (every 60s)"
+      echo "  Log:   /var/log/git-sync.log"
+      echo "  Healthcheck: ${this.deployPath}/bin/git-sync-healthcheck (run via scheduler)"
+    `);
+
+    printStatus('git-sync setup complete');
+  }
+
+  /**
    * Setup Ollama for local LLM support
    */
   async setupOllama() {

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -56,6 +56,14 @@ const SERVICE_MAINTENANCE_JOBS = {
       command: 'systemctl restart resilio-sync || true',
       description: 'Restart Resilio Sync to prevent stale connections'
     }
+  ],
+  'git-sync.timer': [
+    {
+      name: 'git-sync-healthcheck',
+      schedule: '*/5 * * * *', // Every 5 minutes
+      command: 'bin/git-sync-healthcheck',
+      description: 'Check git-sync is firing and surface conflicts in the vault'
+    }
   ]
 };
 

--- a/test/deploy-config.test.js
+++ b/test/deploy-config.test.js
@@ -39,7 +39,8 @@ describe('deploy/config', () => {
         scheduler: config.scheduler === true,
         'vault-web': config['vault-web'] === true,
         'inbox-api': config['inbox-api'] === true,
-        'resilio-sync': config['resilio-sync'] === true
+        'resilio-sync': config['resilio-sync'] === true,
+        'git-sync.timer': config['git-sync.timer'] === true
       };
     }
 


### PR DESCRIPTION
## Summary

- Adds a git-based vault sync alternative to Resilio Sync: a systemd timer pulls/rebases/pushes the vault against its git remote every ~60s (jittered 55–65s).
- No background daemon, no opaque state — conflicts surface as normal `git rebase` failures and get resolved on whichever peer introduced them.
- `--git-sync` and `--resilio` are mutually exclusive `bin/deploy setup` flags; Resilio support is untouched so existing deployments keep working.

## What's new

- **`bin/git-sync`** — `git pull --rebase --autostash && git push`, with stale-rebase recovery and structured exit codes (2 = pull failed, 3 = push failed)
- **`bin/git-sync-healthcheck`** — surfaces conflicts/failures via a `vault/.sync-status.md` marker file so you see them during normal vault use; runs every 5 minutes via the scheduler when `git-sync.timer` is active
- **`deploy/systemd/git-sync.{service,timer}`** — unit files shipped as standalone files (not inline heredocs) so they can be linted, tested, and diffed; timer uses `OnUnitInactiveSec=55s` + `RandomizedDelaySec=10s` to jitter the cadence
- **`setupGitSync()`** on the DigitalOcean provider — installs the units over SSH and enables the timer; refuses if the vault isn't a git checkout or `bin/git-sync` isn't deployed
- **`--git-sync` setup flag** — mutually exclusive with `--resilio`; `bin/deploy <name> setup --git-sync` wires everything up
- **README** — documents both sync options under "Vault & Obsidian", including the important note to add `.git`, `.git.nosync`, and `node_modules` to Resilio's IgnoreList if using it (root cause of a recent outage)

## Why

Our deployment hit a chain of problems with Resilio Sync that took hours to untangle: corrupt `.sync/ID`, an older version with cipher mismatches against newer peers, a `stoppedi1e` state that config.json can't unset, and fundamental `Destination folder is not empty` prompts that can't be auto-confirmed in headless setup. Underlying many of these was Resilio thrashing on an unignored `.git.nosync/` (3.8 GB of git objects generating inotify storms). 

For our vault workflow, where the data is already in git and GitHub is the source of truth, a timer that just `pull --rebase && push` is far simpler, has transparent failure modes, and removes an entire category of sync-daemon mysteries. The old Resilio path stays in place for users who prefer peer-to-peer sync.

## Test plan

- [x] Syntax-check edited JS files (`node --check`)
- [x] `npx jest test/deploy-config.test.js` — 11 tests pass
- [x] Prototype of `bin/git-sync` running under `git-sync.timer` on the production droplet for ~20 minutes: sync succeeds, real pulls and pushes land, log stays quiet, `git-sync-healthcheck` exits 0, no marker file written
- [x] Verified jitter: observed timer firing at 55–65s intervals
- [ ] Not yet exercised: the actual conflict flow (would need to deliberately create a merge conflict between peers)
- [ ] Not yet exercised: `setupGitSync()` on a fresh droplet via `bin/deploy <name> setup --git-sync` (prototype was set up manually; next fresh deploy will be the first real run)
- [ ] Not yet done: Mac-side sync (launchd plist + credential helper) — separate follow-up

## Follow-ups (not in this PR)

- Mac launchd implementation for the peer side
- Deprecate Resilio-specific code once git-sync is proven across all our peers
- Consider adding a `--git-sync` conflict-resolution helper CLI for the rare real-conflict case

🤖 Generated with [Claude Code](https://claude.com/claude-code)