### PR TITLE
fix(git-sync): honor vault_path config setting

### DIFF
--- a/bin/git-sync
+++ b/bin/git-sync
@@ -1,40 +1,101 @@
-#!/bin/bash
-# Sync /opt/today/vault with origin/main via git pull --rebase + push.
-# Designed to run from a systemd timer every ~60s. Exits non-zero on error
-# so systemd reports failure; the timer keeps firing regardless.
+#!/usr/bin/env node
 
-set -o pipefail
+/**
+ * Sync the vault with its git remote via pull --rebase + push.
+ *
+ * Designed to run from a systemd timer (Linux) or launchd agent (macOS)
+ * every ~60s. Exits non-zero on error so the supervisor reports failure;
+ * the next scheduled run retries automatically.
+ *
+ * The vault path is read from config.toml via getAbsoluteVaultPath().
+ * The log path can be overridden with GIT_SYNC_LOG; default is
+ * /var/log/git-sync.log on Linux, ~/Library/Logs/git-sync.log on macOS.
+ *
+ * Exit codes:
+ *   0  success (including no-op runs)
+ *   1  setup / environment problem (not a git repo, no vault, etc.)
+ *   2  git pull --rebase failed (likely a conflict or network error)
+ *   3  git push failed (likely non-fast-forward or auth error)
+ */
 
-VAULT=/opt/today/vault
-LOG=/var/log/git-sync.log
+import { execSync } from 'child_process';
+import { appendFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { getAbsoluteVaultPath } from '../src/config.js';
 
-cd "$VAULT" || { echo "$(date -Iseconds) FATAL cannot cd to $VAULT" >>"$LOG"; exit 1; }
+function defaultLogPath() {
+  if (process.platform === 'darwin') {
+    return join(os.homedir(), 'Library', 'Logs', 'git-sync.log');
+  }
+  return '/var/log/git-sync.log';
+}
 
-log() { echo "$(date -Iseconds) $*" >>"$LOG"; }
+const LOG = process.env.GIT_SYNC_LOG || defaultLogPath();
+const VAULT = getAbsoluteVaultPath();
 
-# Abort any in-progress rebase from a previous failure before trying again.
-GITDIR=$(git rev-parse --git-dir 2>/dev/null) || { log "FATAL not a git repo"; exit 1; }
-if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
-  log "WARN stale rebase state detected, aborting"
-  git rebase --abort 2>>"$LOG" || true
-fi
+function log(msg) {
+  const line = `${new Date().toISOString()} ${msg}\n`;
+  try {
+    appendFileSync(LOG, line);
+  } catch {
+    // Log path may not be writable (e.g. first run on a new system). Fall
+    // back to stderr so the supervisor still sees the message in its journal.
+    process.stderr.write(line);
+  }
+}
 
-# Pull first so we don't push over upstream changes.
-if ! git pull --rebase --autostash 2>>"$LOG"; then
-  log "ERROR pull failed"
-  # If the rebase left state behind, clean up so next run starts fresh.
-  if [ -d "$GITDIR/rebase-merge" ] || [ -d "$GITDIR/rebase-apply" ]; then
-    git rebase --abort 2>>"$LOG" || true
-  fi
-  exit 2
-fi
+function runGit(args) {
+  return execSync(`git ${args}`, {
+    cwd: VAULT,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+}
 
-# Push any local commits.
-if ! git push 2>>"$LOG"; then
-  log "ERROR push failed"
-  exit 3
-fi
+function stderrOf(err) {
+  return (err.stderr && err.stderr.toString().trim()) || err.message || '';
+}
 
-# Only log success if something actually changed, to keep the log quiet.
-# Not strictly necessary; we can refine later.
-exit 0
+if (!existsSync(VAULT)) {
+  log(`FATAL vault path ${VAULT} does not exist`);
+  process.exit(1);
+}
+
+let gitDir;
+try {
+  gitDir = runGit('rev-parse --git-dir').toString().trim();
+  if (!gitDir.startsWith('/')) gitDir = join(VAULT, gitDir);
+} catch (err) {
+  log(`FATAL ${VAULT} is not a git repo: ${stderrOf(err)}`);
+  process.exit(1);
+}
+
+// Clean up stale rebase state from a previous failed run before trying again.
+const rebaseInProgress = () =>
+  existsSync(join(gitDir, 'rebase-merge')) || existsSync(join(gitDir, 'rebase-apply'));
+
+if (rebaseInProgress()) {
+  log('WARN stale rebase state detected, aborting');
+  try { runGit('rebase --abort'); } catch { /* best-effort */ }
+}
+
+// Pull first so we don't push over upstream changes.
+try {
+  runGit('pull --rebase --autostash');
+} catch (err) {
+  log(`ERROR pull failed: ${stderrOf(err)}`);
+  if (rebaseInProgress()) {
+    try { runGit('rebase --abort'); } catch { /* best-effort */ }
+  }
+  process.exit(2);
+}
+
+// Push any local commits.
+try {
+  runGit('push');
+} catch (err) {
+  log(`ERROR push failed: ${stderrOf(err)}`);
+  process.exit(3);
+}
+
+process.exit(0);

--- a/bin/git-sync-healthcheck
+++ b/bin/git-sync-healthcheck
@@ -1,86 +1,129 @@
-#!/bin/bash
-# Vault git-sync health check.
-#
-# Verifies the git-sync.timer is firing successfully. If the last run failed,
-# or the last successful run was too long ago, surfaces a conflict/failure
-# marker in the vault so it's visible during normal use.
-#
-# Intended to run every 5 minutes via the Today scheduler.
+#!/usr/bin/env node
 
-set -o pipefail
+/**
+ * Vault git-sync health check.
+ *
+ * Verifies that git-sync.timer (systemd) or the equivalent supervisor is
+ * firing successfully. If the last run failed, or the last successful run
+ * was too long ago, writes a marker file into the vault so the failure is
+ * visible during normal vault use. Clears the marker on recovery.
+ *
+ * Intended to run every 5 minutes via the Today scheduler.
+ *
+ * Linux-only for now; relies on `systemctl show git-sync.service`. A macOS
+ * launchd-aware variant will be added when we roll out the Mac side.
+ */
 
-UNIT=git-sync.service
-TIMER=git-sync.timer
-VAULT=/opt/today/vault
-MARKER="$VAULT/.sync-status.md"
-MAX_STALE_SECONDS=600  # 10 minutes — alert if no successful run in this window
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync, existsSync } from 'fs';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getAbsoluteVaultPath } from '../src/config.js';
 
-# Only check if the timer is enabled
-if ! systemctl is-enabled --quiet "$TIMER" 2>/dev/null; then
-  exit 0
-fi
+const UNIT = 'git-sync.service';
+const TIMER = 'git-sync.timer';
+const MAX_STALE_SECONDS = 600; // 10 minutes — alert if no successful run in this window
 
-# Look at the last run result
-last_result=$(systemctl show "$UNIT" --property=Result --value 2>/dev/null)
-last_exit_status=$(systemctl show "$UNIT" --property=ExecMainStatus --value 2>/dev/null)
-last_exit_ts=$(systemctl show "$UNIT" --property=ExecMainExitTimestampMonotonic --value 2>/dev/null)
+const VAULT = getAbsoluteVaultPath();
+const MARKER = join(VAULT, '.sync-status.md');
 
-# Compute seconds since last exit (monotonic clock)
-now_mono=$(awk '{print int($1 * 1000000)}' /proc/uptime)
-if [ -n "$last_exit_ts" ] && [ "$last_exit_ts" -gt 0 ] 2>/dev/null; then
-  elapsed=$(( (now_mono - last_exit_ts) / 1000000 ))
-else
-  elapsed=-1
-fi
+function systemctlShow(unit, property) {
+  try {
+    return execSync(`systemctl show ${unit} --property=${property} --value`, {
+      stdio: ['ignore', 'pipe', 'pipe']
+    }).toString().trim();
+  } catch {
+    return '';
+  }
+}
 
-write_marker() {
-  local status="$1"
-  local detail="$2"
-  cat > "$MARKER" << EOF
----
+function isEnabled(unit) {
+  try {
+    execSync(`systemctl is-enabled --quiet ${unit}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function uptimeMicroseconds() {
+  // /proc/uptime first field is seconds since boot (monotonic clock)
+  const uptimeSec = parseFloat(readFileSync('/proc/uptime', 'utf8').split(' ')[0]);
+  return Math.floor(uptimeSec * 1_000_000);
+}
+
+function writeMarker(status, detail, lastResult, lastExitStatus, elapsed) {
+  const body = `---
 tags: [sync, alert]
-updated: $(date -Iseconds)
+updated: ${new Date().toISOString()}
 ---
 # ⚠ Vault sync alert
 
-**Status:** $status
-**Last run result:** $last_result (exit $last_exit_status)
-**Last run:** ${elapsed}s ago
-**Detail:** $detail
+**Status:** ${status}
+**Last run result:** ${lastResult} (exit ${lastExitStatus})
+**Last run:** ${elapsed >= 0 ? elapsed + 's ago' : 'unknown'}
+**Detail:** ${detail}
 
 Investigate with:
 \`\`\`
-systemctl status $UNIT
-journalctl -u $UNIT --since '1 hour ago'
+systemctl status ${UNIT}
+journalctl -u ${UNIT} --since '1 hour ago'
 tail -50 /var/log/git-sync.log
 \`\`\`
 
 Resolve conflicts on the peer where they were introduced, then delete this file.
-EOF
+`;
+  writeFileSync(MARKER, body);
 }
 
-clear_marker() {
-  [ -f "$MARKER" ] && rm -f "$MARKER"
+function clearMarker() {
+  if (existsSync(MARKER)) {
+    try { unlinkSync(MARKER); } catch { /* best-effort */ }
+  }
 }
 
-# Decide status
-if [ "$last_result" = "success" ] && [ "$last_exit_status" = "0" ]; then
-  if [ "$elapsed" -ge 0 ] && [ "$elapsed" -gt "$MAX_STALE_SECONDS" ]; then
-    write_marker "STALE" "Last success was ${elapsed}s ago; timer may be stopped or stuck."
-    exit 1
-  fi
-  clear_marker
-  exit 0
-fi
+// Only check if the timer is enabled (and therefore meant to be running).
+if (!isEnabled(TIMER)) {
+  process.exit(0);
+}
 
-if [ "$last_result" = "exit-code" ]; then
-  case "$last_exit_status" in
-    2) write_marker "PULL FAILED" "git pull --rebase failed — likely a conflict or network error." ;;
-    3) write_marker "PUSH FAILED" "git push failed — likely a non-fast-forward or auth error." ;;
-    *) write_marker "FAILED" "git-sync exited with status $last_exit_status." ;;
-  esac
-  exit 1
-fi
+const lastResult = systemctlShow(UNIT, 'Result');
+const lastExitStatus = systemctlShow(UNIT, 'ExecMainStatus');
+const lastExitMono = systemctlShow(UNIT, 'ExecMainExitTimestampMonotonic');
 
-# Unknown state — don't flap the marker
-exit 0
+let elapsed = -1;
+if (lastExitMono && Number(lastExitMono) > 0) {
+  elapsed = Math.floor((uptimeMicroseconds() - Number(lastExitMono)) / 1_000_000);
+}
+
+if (lastResult === 'success' && lastExitStatus === '0') {
+  if (elapsed >= 0 && elapsed > MAX_STALE_SECONDS) {
+    writeMarker(
+      'STALE',
+      `Last success was ${elapsed}s ago; timer may be stopped or stuck.`,
+      lastResult, lastExitStatus, elapsed
+    );
+    process.exit(1);
+  }
+  clearMarker();
+  process.exit(0);
+}
+
+if (lastResult === 'exit-code') {
+  const detailByStatus = {
+    '2': 'git pull --rebase failed — likely a conflict or network error.',
+    '3': 'git push failed — likely a non-fast-forward or auth error.'
+  };
+  const label = lastExitStatus === '2' ? 'PULL FAILED'
+              : lastExitStatus === '3' ? 'PUSH FAILED'
+              : 'FAILED';
+  writeMarker(
+    label,
+    detailByStatus[lastExitStatus] || `git-sync exited with status ${lastExitStatus}.`,
+    lastResult, lastExitStatus, elapsed
+  );
+  process.exit(1);
+}
+
+// Unknown state (no exit info yet, timer just enabled, etc.) — don't flap.
+process.exit(0);


### PR DESCRIPTION
## Summary

Follow-up to #197. The bash versions of `bin/git-sync` and `bin/git-sync-healthcheck` hardcoded `/opt/today/vault`, ignoring the `vault_path` setting in `config.toml`. They worked on the default deployment by coincidence only.

Rewrites both as Node scripts so they import `getAbsoluteVaultPath()` from `src/config.js` directly, matching the pattern used by `bin/tasks`, `bin/prerender`, and the other Node-based bin commands.

## Changes

- **`bin/git-sync`** — rewritten in Node. Reads the vault path from config, exits with the same 1/2/3 codes as before, same stale-rebase recovery.
- **`bin/git-sync-healthcheck`** — rewritten in Node. Same systemctl-based check, same marker-file behavior, now reads the vault path from config so it writes the marker to the right place.
- **Platform-aware default log path**: `/var/log/git-sync.log` on Linux, `~/Library/Logs/git-sync.log` on macOS. Override with `GIT_SYNC_LOG` env var (systemd unit or launchd plist can set it explicitly).
- **Stderr fallback** if the log file isn't writable on first run, so the supervisor captures the message in its journal.

## Test plan

- [x] `node --check` both files
- [x] Direct invocation on the droplet: `bin/git-sync` → exit 0, pull + push logged
- [x] Direct invocation: `bin/git-sync-healthcheck` → exit 0, no marker file in the vault
- [x] `getAbsoluteVaultPath()` resolves to `/opt/today/vault` as expected (config default, matches the previous hardcoded path — so the droplet keeps working without migration)
- [x] systemd `git-sync.service` fires the new script successfully (status shows `code=exited, status=0/SUCCESS`, 417ms runtime vs ~289ms for bash — well under the 55-65s timer window)
- [ ] Not yet exercised: a deployment where `vault_path` in config.toml is non-default — but that was the whole point of this PR, so the test plan is just "we don't hardcode it anymore"

🤖 Generated with [Claude Code](https://claude.com/claude-code)