### PR TITLE
feat(deploy): add local provider for docker-compose deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,47 @@ Deployment copies your **local configuration** to the remote server, making the 
 | `digitalocean` | DigitalOcean Droplets with automated setup |
 | `hetzner` | Hetzner Cloud servers |
 | `generic` | Any VPS with SSH access |
+| `local` | The current machine, managed via docker-compose (e.g. running Today on a Mac) |
+
+### Local deployments (running Today on a Mac via Docker)
+
+A `local` deployment configures the machine you're on instead of SSHing to a remote. It's designed for running the Today containers via docker-compose on a Mac (or a Linux dev machine) while still using the same `config.toml` → `bin/deploy` → scheduler model as the remote droplets.
+
+Example config.toml entry for a Mac:
+
+```toml
+[deployments.local.macbook]
+deploy_path = "/Users/you/today"
+enabled = true
+
+[deployments.local.macbook.services]
+scheduler = true
+
+[deployments.local.macbook.jobs.plugin-sync]
+schedule = "*/10 * * * *"
+command = "bin/plugins sync"
+
+[deployments.local.macbook.jobs.git-sync]
+schedule = "* * * * *"
+command = "bin/git-sync"
+description = "Pull/rebase/push vault via git"
+```
+
+Then on the Mac:
+
+```bash
+bin/deploy macbook setup       # one-time: docker compose build
+bin/deploy macbook              # write scheduler-config.json and `docker compose up -d scheduler`
+bin/deploy macbook services     # show compose service status
+bin/deploy macbook logs scheduler
+```
+
+A few things to know about local deployments:
+
+- **No systemd, no apt.** Service management maps to `docker compose up/stop/restart/ps`; package install is the image's job.
+- **git-sync as a scheduler job.** On remote deployments, `--git-sync` installs a systemd timer out-of-band. On local deployments, git-sync runs as a regular cron entry inside the scheduler container — add it to `[deployments.local.<name>.jobs.git-sync]` as in the example above. Running `bin/deploy <name> setup --git-sync` on a local deployment prints a reminder rather than installing anything.
+- **Resilio Sync is not supported** on local deployments (`--resilio` emits a warning and exits).
+- **Git push credentials inside the container**: the compose file bind-mounts `~/.ssh` read-only, so SSH URLs just work. If your vault remote is HTTPS, switch it: `cd <vault> && git remote set-url origin git@github.com:<user>/<vault>.git`. macOS Keychain credential helpers don't work inside a Linux container.
 
 ### Services & Jobs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,32 @@ services:
     depends_on:
       - ollama
 
+  # Scheduler service for local deployments.
+  #
+  # Runs node src/scheduler.js as a long-lived process, so user-configured
+  # cron jobs (plugin-sync, git-sync, etc.) fire without needing systemd
+  # on the host. Enable it per-deployment via `bin/deploy <name>` — the
+  # local provider will bring this up via `docker compose up -d scheduler`.
+  #
+  # Jobs are read from .data/scheduler-config.json, which `bin/deploy`
+  # writes from [deployments.local.<name>.jobs.*] in config.toml.
+  scheduler:
+    build: .
+    container_name: today-scheduler
+    command: ["node", "src/scheduler.js"]
+    environment:
+      - DOTENV_PRIVATE_KEY=${DOTENV_PRIVATE_KEY}
+      - SKIP_DEP_CHECK=true
+      - OLLAMA_HOST=http://ollama:11434
+    volumes:
+      - .:/app
+      - calendar-cache:/app/.calendar-cache
+      - /app/node_modules
+      - ~/.ssh:/root/.ssh:ro
+    restart: unless-stopped
+    depends_on:
+      - ollama
+
   ollama:
     image: ollama/ollama:latest
     container_name: ollama

--- a/src/deploy/commands/deploy.js
+++ b/src/deploy/commands/deploy.js
@@ -20,6 +20,12 @@ export async function deployCommand(server, args = []) {
     process.exit(1);
   }
 
+  // Local deployments take a very different path: no code sync, no apt,
+  // no systemd, just "write config, (re)start compose services".
+  if (server.provider === 'local') {
+    return deployLocal(server);
+  }
+
   const deployPath = server.deployPath;
 
   // Create directories
@@ -236,6 +242,76 @@ async function cleanupStaleServices(server, currentServiceFiles) {
   server.sshCmd('systemctl daemon-reload');
   server.sshCmd('systemctl reset-failed', { check: false });
   printStatus(`Removed ${staleServices.length} stale service(s)`);
+}
+
+/**
+ * Deploy to a local provider (docker-compose-based).
+ *
+ * Skips all the SSH/systemd/apt/rsync plumbing that doesn't apply on the
+ * current machine. The important bits — writing scheduler-config.json so
+ * the scheduler knows which jobs to run, and bringing compose services up
+ * — still happen.
+ */
+async function deployLocal(server) {
+  const deployPath = server.deployPath;
+
+  // Ensure the .data directory exists for state files
+  printInfo(`Deploying to local deployment at ${deployPath}...`);
+  fs.mkdirSync(path.join(deployPath, '.data'), { recursive: true });
+
+  // Write deployment name file (used for runtime AI config overrides)
+  printInfo(`Setting deployment name: ${server.name}`);
+  fs.writeFileSync(path.join(deployPath, '.data', 'deployment-name'), server.name + '\n');
+
+  // Apply deployment-specific AI overrides to config (only if config is NOT in vault)
+  const { getConfigPath } = await import('../../config.js');
+  const configPath = getConfigPath();
+  const relativeConfigPath = configPath.replace(PROJECT_ROOT + '/', '');
+  const configInVault = relativeConfigPath.startsWith('vault/');
+
+  if (server.ai && !configInVault && PROJECT_ROOT === deployPath) {
+    printInfo('Applying deployment AI configuration...');
+    const { applyDeploymentOverrides } = await import('../../config.js');
+    applyDeploymentOverrides(server.ai, configPath);
+    printStatus('AI configuration applied');
+  } else if (server.ai && configInVault) {
+    printInfo('AI overrides will be applied at runtime (config in vault)');
+  }
+
+  // Write scheduler jobs config from config.toml's [deployments.*.jobs.*]
+  if (server.jobs && Object.keys(server.jobs).length > 0) {
+    printInfo('Writing scheduler jobs config...');
+    const jobsConfigPath = path.join(deployPath, '.data', 'scheduler-config.json');
+    fs.writeFileSync(jobsConfigPath, JSON.stringify(server.jobs, null, 2) + '\n');
+    printStatus(`Configured ${Object.keys(server.jobs).length} scheduled job(s)`);
+  }
+
+  // Bring up enabled compose services. The LocalProvider's systemctl
+  // override translates these into `docker compose up -d <name>` calls.
+  const enabledServices = Object.entries(server.services || {})
+    .filter(([_, enabled]) => enabled)
+    .map(([name]) => name === 'scheduler' ? 'today-scheduler' : name);
+
+  if (enabledServices.length > 0) {
+    printInfo(`Starting configured services: ${enabledServices.join(', ')}`);
+    for (const service of enabledServices) {
+      // `enable` + `restart` both map to compose commands; restart handles
+      // the "already running, pick up new config" case.
+      server.systemctl('enable', service, { check: false });
+      server.systemctl('restart', service, { check: false });
+    }
+    printStatus(`Started ${enabledServices.length} service(s)`);
+  } else {
+    printInfo('No services configured. Enable in config.toml under [deployments.local.*.services]');
+  }
+
+  printStatus('Local deployment complete!');
+  console.log('');
+  console.log(`  Deploy path: ${deployPath}`);
+  if (enabledServices.length > 0) {
+    console.log(`  Services:    ${enabledServices.join(', ')}`);
+    console.log(`  Logs:        docker compose logs -f <service>`);
+  }
 }
 
 export default deployCommand;

--- a/src/deploy/commands/services.js
+++ b/src/deploy/commands/services.js
@@ -28,7 +28,12 @@ export async function servicesCommand(server, args = []) {
     console.log(`📋 Services on ${server.name}:`);
     console.log('');
 
-    server.sshScript(`
+    if (server.provider === 'local') {
+      // Local deployments use docker-compose, not systemd. Ask compose
+      // which services are up instead of shelling to systemctl.
+      server.sshCmd('docker compose ps --format "  {{if eq .State \\"running\\"}}✓{{else}}○{{end}} {{.Service}} ({{.State}})" 2>/dev/null || docker compose ps', { check: false });
+    } else {
+      server.sshScript(`
 for service in ${SERVICES.join(' ')}; do
     if systemctl is-active --quiet $service 2>/dev/null; then
         echo "  ✓ $service (running)"
@@ -39,6 +44,7 @@ for service in ${SERVICES.join(' ')}; do
     fi
 done
 `);
+    }
     return;
   }
 

--- a/src/deploy/commands/setup.js
+++ b/src/deploy/commands/setup.js
@@ -4,7 +4,7 @@
  * Initial server setup - installs dependencies, configures services
  */
 
-import { printStatus, printInfo, printWarning, printError } from '../remote-server.js';
+import { printStatus, printInfo, printError } from '../remote-server.js';
 
 export async function setupCommand(server, args = []) {
   console.log(`🚀 Setting up ${server.name} (${server.provider})...`);
@@ -69,12 +69,15 @@ export async function setupCommand(server, args = []) {
     await server.setupSsl();
   }
 
-  // Optional: Resilio Sync
+  // Optional: Resilio Sync. Providers that don't support it (e.g. local)
+  // should define a setupResilioSync() that prints a clear warning.
   if (withResilio && typeof server.setupResilioSync === 'function') {
     await server.setupResilioSync();
   }
 
-  // Optional: git-sync
+  // Optional: git-sync. On remote providers this installs the systemd
+  // timer; on local providers it prints guidance on adding the job to
+  // config.toml (see LocalProvider.setupGitSync).
   if (withGitSync && typeof server.setupGitSync === 'function') {
     await server.setupGitSync();
   }

--- a/src/deploy/config.js
+++ b/src/deploy/config.js
@@ -120,7 +120,9 @@ export function getDeployments() {
         continue;
       }
 
-      const ip = getDeploymentIp(provider, name);
+      // Local deployments don't need an IP — they run on the current
+      // machine. Everything else uses the environment-variable lookup.
+      const ip = provider === 'local' ? 'localhost' : getDeploymentIp(provider, name);
 
       // Parse services config (default all to false for safety)
       const servicesConfig = deploymentConfig.services || {};
@@ -128,7 +130,8 @@ export function getDeployments() {
         scheduler: servicesConfig.scheduler === true,
         'vault-web': servicesConfig['vault-web'] === true,
         'inbox-api': servicesConfig['inbox-api'] === true,
-        'resilio-sync': servicesConfig['resilio-sync'] === true
+        'resilio-sync': servicesConfig['resilio-sync'] === true,
+        'git-sync.timer': servicesConfig['git-sync.timer'] === true
       };
 
       // Parse jobs config (use defaults if not specified)

--- a/src/deploy/providers/index.js
+++ b/src/deploy/providers/index.js
@@ -7,6 +7,7 @@
 import { DigitalOceanProvider } from './digitalocean.js';
 import { HetznerProvider } from './hetzner.js';
 import { GenericVpsProvider } from './generic-vps.js';
+import { LocalProvider } from './local.js';
 
 export const providers = {
   'digitalocean': DigitalOceanProvider,
@@ -14,6 +15,7 @@ export const providers = {
   'generic-vps': GenericVpsProvider,
   'generic': GenericVpsProvider,  // alias
   'vps': GenericVpsProvider,      // alias
+  'local': LocalProvider,
 };
 
 /**
@@ -43,6 +45,7 @@ export function listProviders() {
     { name: 'digitalocean', label: 'DigitalOcean', description: 'DigitalOcean Droplets' },
     { name: 'hetzner', label: 'Hetzner', description: 'Hetzner Cloud servers' },
     { name: 'generic-vps', label: 'Generic VPS', description: 'Any Linux VPS with SSH access' },
+    { name: 'local', label: 'Local', description: 'The current machine (Mac, dev laptop) via docker-compose' },
   ];
 }
 

--- a/src/deploy/providers/local.js
+++ b/src/deploy/providers/local.js
@@ -1,0 +1,298 @@
+/**
+ * Local Provider
+ *
+ * Treats the current machine as a deployment target instead of SSHing to
+ * a remote server. Orchestrates docker-compose services on the host (Mac
+ * or Linux) and writes configuration files directly to the local
+ * filesystem.
+ *
+ * Use this provider for local development setups and for configuring the
+ * machine you're on (e.g. a Mac where Today runs in Docker). Each local
+ * deployment is identified by its `deploy_path`, which should point at the
+ * Today checkout on that machine.
+ *
+ * What this provider does NOT do, in contrast to the SSH providers:
+ * - It does not rsync or git-pull code (the local checkout IS the code).
+ * - It does not install systemd units (there's no systemd inside a Mac
+ *   Docker container; services are managed via docker-compose instead).
+ * - It does not run apt-get or install packages (the container image is
+ *   responsible for its own dependencies).
+ *
+ * Service management maps to docker-compose:
+ *   systemctl start foo   -> docker compose up -d foo
+ *   systemctl stop foo    -> docker compose stop foo
+ *   systemctl restart foo -> docker compose restart foo
+ *   systemctl status foo  -> docker compose ps foo
+ *   journalctl -u foo     -> docker compose logs foo
+ */
+
+import { RemoteServer, printStatus, printInfo, printWarning } from '../remote-server.js';
+import { execSync, spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Map a systemd service name to its docker-compose service name.
+ *
+ * The Today codebase uses systemd-style names everywhere (today-scheduler,
+ * vault-watcher, etc.). When running locally via docker-compose, those map
+ * to simpler compose service names.
+ */
+const SYSTEMD_TO_COMPOSE = {
+  'today-scheduler': 'scheduler',
+  'scheduler': 'scheduler',
+  'vault-watcher': 'vault-watcher',
+  'vault-web': 'vault-web',
+  'inbox-api': 'inbox-api',
+  'today': 'today'
+};
+
+function toComposeService(service) {
+  // Drop .timer / .service suffixes systemd uses.
+  const bare = service.replace(/\.(service|timer)$/, '');
+  return SYSTEMD_TO_COMPOSE[bare] || bare;
+}
+
+export class LocalProvider extends RemoteServer {
+  constructor(config) {
+    super(config);
+
+    // On a local deployment the "deploy path" is the Today checkout on
+    // this machine. If the user didn't set one in config.toml, default to
+    // the current project root — this provider runs inside the same repo
+    // that owns it.
+    if (!config.deploy_path && !config.deployPath) {
+      this.deployPath = process.cwd();
+    }
+
+    // SSH settings are irrelevant but keep the fields populated so code
+    // that reads them doesn't blow up.
+    this.ip = 'localhost';
+    this.sshUser = process.env.USER || 'local';
+    this.sshPort = 0;
+    this.sshKeyPath = null;
+  }
+
+  // --- Overrides that make RemoteServer methods run locally ------------
+
+  /** Local deployments skip the SSH-key/IP checks. */
+  validate() {
+    if (!fs.existsSync(this.deployPath)) {
+      printWarning(`Deploy path does not exist: ${this.deployPath}`);
+      return false;
+    }
+    return true;
+  }
+
+  /** Execute a shell command in the deploy directory. */
+  sshCmd(command, options = {}) {
+    const { check = true, capture = false } = options;
+    try {
+      if (capture) {
+        const stdout = execSync(command, {
+          cwd: this.deployPath,
+          encoding: 'utf8',
+          shell: '/bin/bash'
+        });
+        return { stdout, returncode: 0 };
+      }
+      execSync(command, {
+        cwd: this.deployPath,
+        stdio: 'inherit',
+        shell: '/bin/bash'
+      });
+      return { returncode: 0 };
+    } catch (e) {
+      if (check) process.exit(e.status || 1);
+      return {
+        stdout: (e.stdout && e.stdout.toString()) || '',
+        stderr: (e.stderr && e.stderr.toString()) || '',
+        returncode: e.status || 1
+      };
+    }
+  }
+
+  /** Execute a multi-line script locally. */
+  sshScript(script, options = {}) {
+    return this.sshCmd(script, options);
+  }
+
+  /**
+   * "Copy" a file into the deploy tree. If the source and destination
+   * resolve to the same file we no-op instead of doing a self-copy.
+   */
+  scpToRemote(localPath, remotePath) {
+    const destAbs = path.isAbsolute(remotePath)
+      ? remotePath
+      : path.join(this.deployPath, remotePath);
+    if (path.resolve(localPath) === path.resolve(destAbs)) {
+      return;
+    }
+    fs.mkdirSync(path.dirname(destAbs), { recursive: true });
+    fs.copyFileSync(localPath, destAbs);
+  }
+
+  scpFromRemote(remotePath, localPath) {
+    const srcAbs = path.isAbsolute(remotePath)
+      ? remotePath
+      : path.join(this.deployPath, remotePath);
+    if (path.resolve(srcAbs) === path.resolve(localPath)) return;
+    fs.mkdirSync(path.dirname(localPath), { recursive: true });
+    fs.copyFileSync(srcAbs, localPath);
+  }
+
+  /** Rsync is a no-op locally — the code already lives at deployPath. */
+  rsyncToRemote(_localPath, _remotePath, ..._extraArgs) {
+    // no-op on local deployments
+  }
+
+  rsyncFromRemote(_remotePath, _localPath, ..._extraArgs) {
+    // no-op on local deployments
+  }
+
+  /** Open an interactive shell in the deploy directory. */
+  sshInteractive() {
+    const result = spawnSync(process.env.SHELL || '/bin/bash', [], {
+      cwd: this.deployPath,
+      stdio: 'inherit'
+    });
+    return result.status || 0;
+  }
+
+  /**
+   * Map systemd-style service management to docker-compose on the local
+   * machine. `systemctl status foo` becomes `docker compose ps foo`, etc.
+   */
+  systemctl(action, service, options = {}) {
+    const svc = toComposeService(service);
+    const { check = false } = options;
+    let cmd;
+    switch (action) {
+      case 'start':
+      case 'enable':
+        cmd = `docker compose up -d ${svc}`;
+        break;
+      case 'stop':
+      case 'disable':
+        cmd = `docker compose stop ${svc}`;
+        break;
+      case 'restart':
+        cmd = `docker compose restart ${svc}`;
+        break;
+      case 'status':
+        cmd = `docker compose ps ${svc}`;
+        break;
+      case 'is-active':
+        // Exit 0 if the compose service has a running container.
+        cmd = `[ -n "$(docker compose ps -q ${svc} 2>/dev/null)" ]`;
+        break;
+      default:
+        cmd = `docker compose ${action} ${svc}`;
+    }
+    return this.sshCmd(cmd, { check });
+  }
+
+  serviceStatus(service) {
+    return this.systemctl('status', service, { check: false });
+  }
+
+  viewLogs(service, options = {}) {
+    const { follow = false, lines = 100 } = options;
+    const svc = toComposeService(service);
+    const followFlag = follow ? '-f' : '';
+    this.sshCmd(`docker compose logs ${followFlag} --tail=${lines} ${svc}`);
+  }
+
+  /** Execute a command with deployPath as the working directory. */
+  exec(command) {
+    console.log(`⚡ Executing: ${command}`);
+    return this.sshCmd(command);
+  }
+
+  async testConnection() {
+    return fs.existsSync(this.deployPath);
+  }
+
+  getServerInfo() {
+    return {
+      name: this.name,
+      provider: this.provider,
+      location: 'local',
+      deployPath: this.deployPath
+    };
+  }
+
+  // --- Setup hooks ------------------------------------------------------
+
+  /**
+   * Local deployments don't provision the host — docker-compose does.
+   * The setup command still invokes this, so we give the user a clear
+   * summary of what needs to be in place before `bin/deploy <name>` will
+   * succeed.
+   */
+  async setup() {
+    printInfo(`Preparing local deployment at ${this.deployPath}...`);
+
+    if (!fs.existsSync(this.deployPath)) {
+      printWarning(`${this.deployPath} does not exist. Create the Today checkout there first.`);
+      return;
+    }
+
+    const composeFile = path.join(this.deployPath, 'docker-compose.yml');
+    if (!fs.existsSync(composeFile)) {
+      printWarning(`No docker-compose.yml at ${composeFile}. A local deployment needs compose to manage services.`);
+      return;
+    }
+
+    // Build any images the compose file describes so the first `up` doesn't
+    // stall on a download.
+    printInfo('Building docker-compose images (this may take a few minutes the first time)...');
+    this.sshCmd('docker compose build', { check: false });
+
+    printStatus('Local deployment setup complete');
+    console.log('');
+    console.log('Next steps:');
+    console.log(`  1. bin/deploy ${this.name}            # Apply config and start services`);
+    console.log('');
+    console.log('Vault sync:');
+    console.log('  For local deployments, configure git-sync as a scheduler job in config.toml:');
+    console.log('');
+    console.log(`    [deployments.local.${this.name}.jobs.git-sync]`);
+    console.log('    schedule = "* * * * *"');
+    console.log('    command = "bin/git-sync"');
+    console.log('');
+    console.log('  And make sure your vault remote is SSH so the container can push without a credential helper:');
+    console.log('    cd <your-vault>');
+    console.log('    git remote set-url origin git@github.com:<user>/<vault-repo>.git');
+  }
+
+  /**
+   * Resilio Sync is systemd-based and not supported on local deployments.
+   * The setup command catches this and tells the user to use git-sync.
+   */
+  async setupResilioSync() {
+    printWarning('Resilio Sync is not supported on local deployments.');
+    console.log('  Use git-sync instead: add a git-sync job to your config.toml under');
+    console.log(`    [deployments.local.${this.name}.jobs.git-sync]`);
+  }
+
+  /**
+   * For local deployments git-sync is a scheduler job rather than an
+   * out-of-band systemd timer, so there's no separate install step. We
+   * print guidance and exit without modifying anything.
+   */
+  async setupGitSync() {
+    printInfo('Local deployments run git-sync as a scheduler job, not a systemd timer.');
+    console.log('');
+    console.log('Add this to your config.toml under the deployment block:');
+    console.log('');
+    console.log(`  [deployments.local.${this.name}.jobs.git-sync]`);
+    console.log('  schedule = "* * * * *"');
+    console.log('  command = "bin/git-sync"');
+    console.log('  description = "Pull/rebase/push vault via git"');
+    console.log('');
+    console.log(`Then: bin/deploy ${this.name}`);
+  }
+}
+
+export default LocalProvider;

--- a/test/deploy-config.test.js
+++ b/test/deploy-config.test.js
@@ -136,6 +136,28 @@ describe('deploy/config', () => {
       expect(Object.keys(jobs).length).toBe(1);
       expect(jobs['valid']).toBeDefined();
     });
+
+    test('git-sync can be configured as a scheduler job for local deployments', () => {
+      // This is the documented shape for enabling git-sync on a local
+      // deployment; it lives alongside plugin-sync in config.toml under
+      // [deployments.local.<name>.jobs.git-sync].
+      const jobs = parseJobs({
+        'plugin-sync': {
+          schedule: '*/10 * * * *',
+          command: 'bin/plugins sync'
+        },
+        'git-sync': {
+          schedule: '* * * * *',
+          command: 'bin/git-sync',
+          description: 'Pull/rebase/push vault via git'
+        }
+      });
+
+      expect(jobs['git-sync']).toBeDefined();
+      expect(jobs['git-sync'].schedule).toBe('* * * * *');
+      expect(jobs['git-sync'].command).toBe('bin/git-sync');
+      expect(jobs['plugin-sync']).toBeDefined();
+    });
   });
 
   describe('deployment config structure', () => {


### PR DESCRIPTION
## Summary

Adds a `local` deployment provider so the same `config.toml` → `bin/deploy` → scheduler model used for remote droplets also works for the machine you're on — specifically, running Today in Docker on a Mac.

Before this PR, configuring which jobs run on a Mac meant either hand-editing `.data/scheduler-config.json` or running the scheduler outside the project entirely. After, each Mac gets a `[deployments.local.<name>]` entry in `config.toml` — same shape as the droplet — and `bin/deploy macbook` writes its scheduler config and brings up the compose services.

## What's new

- **`src/deploy/providers/local.js`** — a new `LocalProvider` that extends `RemoteServer`. Overrides SSH/rsync/systemctl to run on the current machine; service management maps to `docker compose up -d / stop / restart / ps / logs`. Setup hooks for Resilio (unsupported on local) and git-sync (scheduler job instead of systemd timer) print clear guidance.
- **`docker-compose.yml`** — new `scheduler` compose service running `node src/scheduler.js`, `restart: unless-stopped`. Same image as `today`, different command. This is what the local deployment's scheduler jobs run under.
- **`src/deploy/commands/deploy.js`** — new `deployLocal()` code path that skips everything SSH/apt/systemd/rsync-shaped (since it doesn't apply) and focuses on writing `.data/scheduler-config.json` + starting compose services.
- **`src/deploy/commands/services.js`** — `bin/deploy <local-name> services` uses `docker compose ps` instead of systemctl for the status listing.
- **`src/deploy/config.js`** — local deployments skip the `DEPLOY_*_IP` env-var lookup and just set ip to `localhost`. Also adds `git-sync.timer` to the parsed services map so it round-trips cleanly.
- **Documentation** — README section showing the `config.toml` shape for a Mac, the commands to run, and the SSH remote-URL requirement for pushing from inside the container.
- **Tests** — extended `test/deploy-config.test.js` to cover git-sync configured as a regular scheduler job.

## Design decision: git-sync on local deployments

`--git-sync` on a *remote* deployment is special because systemd needs an out-of-band install step (unit files, enabling the timer). On a *local* deployment there's no equivalent — scheduler + jobs are already driven by `config.toml` + the compose file. So on local, git-sync is configured the same way any other scheduler job is: an entry under `[deployments.local.<name>.jobs.git-sync]`. `bin/deploy <name> setup --git-sync` on a local deployment prints a reminder instead of installing anything.

This keeps `config.toml` as the single source of truth for "which jobs run where," across both remote and local, without introducing a parallel mechanism.

## Example usage

```toml
[deployments.local.macbook]
deploy_path = "/Users/jeff/today"
enabled = true

[deployments.local.macbook.services]
scheduler = true

[deployments.local.macbook.jobs.plugin-sync]
schedule = "*/10 * * * *"
command = "bin/plugins sync"

[deployments.local.macbook.jobs.git-sync]
schedule = "* * * * *"
command = "bin/git-sync"
description = "Pull/rebase/push vault via git"
```

```bash
bin/deploy macbook setup        # docker compose build (one-time)
bin/deploy macbook              # write scheduler-config.json + compose up -d scheduler
bin/deploy macbook services     # docker compose ps
bin/deploy macbook logs scheduler
```

## Test plan

- [x] `node --check` all edited files
- [x] `NODE_OPTIONS='--experimental-vm-modules' npx jest test/deploy-config.test.js` — 12 tests pass (one new case for git-sync as scheduler job)
- [ ] **Not yet exercised**: end-to-end run of `bin/deploy macbook` on an actual Mac — this PR is the code, the next step is you pulling it on a Mac and trying it. We'll iterate on any rough edges found there.

## Follow-ups (not in this PR)

- The Mac-side end-to-end test (you'll drive this, I'll fix things as they come up)
- Once local deployments are proven, document the full workflow for bringing up a new Mac
- Eventually: deprecate Resilio-specific code when all peers are on git-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)