### PR TITLE
fix(local-deploy): devcontainer Docker CLI + git-sync in configure UI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,19 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:20
 # Note: python3 is required for node-gyp to compile native modules like better-sqlite3
 RUN apt-get update && apt-get install -y python3 make g++ sqlite3 curl && rm -rf /var/lib/apt/lists/*
 
+# Install Docker CLI + Compose plugin so `bin/deploy <local-name>` works from
+# inside the devcontainer. We do NOT install the Docker daemon — the devcontainer
+# talks to the HOST's daemon via a bind-mounted /var/run/docker.sock (see
+# .devcontainer/docker-compose.yml). This is the standard "docker-outside-of-docker"
+# pattern.
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install Turso CLI manually (avoid auto-auth issues)
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; fi && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,9 @@
 	"postStartCommand": "bash .devcontainer/devcontainer-startup",
 	"containerEnv": {
 		"DEVCONTAINER_HOST_MACHINE": "${localEnv:HOSTNAME}${localEnv:COMPUTERNAME}",
-		"DEVCONTAINER_PROJECT": "today"
+		"DEVCONTAINER_PROJECT": "today",
+		"HOST_PROJECT_PATH": "${localWorkspaceFolder}",
+		"HOST_HOME": "${localEnv:HOME}"
 	},
 	"remoteEnv": {
 		"PATH": "/home/node/.local/bin:/home/node/.fly/bin:${containerEnv:PATH}"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,18 @@ services:
     init: true
     volumes:
       - ..:/workspaces/today:cached
+      # Mount the host Docker daemon socket so `docker` / `docker compose`
+      # commands run inside the devcontainer talk to the host daemon. This
+      # is what makes `bin/deploy <local-name>` work from inside the
+      # devcontainer.
+      - /var/run/docker.sock:/var/run/docker.sock
     command: sleep infinity
     environment:
       - DEVCONTAINER_PROJECT=today
+      # Absolute HOST path of the project root. Used when compose bring-up
+      # commands run from inside the devcontainer: docker-compose resolves
+      # bind-mount source paths against this, so the daemon sees paths that
+      # exist on the host rather than /workspaces/today (which only exists
+      # inside the devcontainer). The value is injected by
+      # generate-compose-override.sh on the host side.
+      - HOST_PROJECT_PATH=${HOST_PROJECT_PATH:-}

--- a/README.md
+++ b/README.md
@@ -370,9 +370,10 @@ bin/deploy macbook logs scheduler
 A few things to know about local deployments:
 
 - **No systemd, no apt.** Service management maps to `docker compose up/stop/restart/ps`; package install is the image's job.
-- **git-sync as a scheduler job.** On remote deployments, `--git-sync` installs a systemd timer out-of-band. On local deployments, git-sync runs as a regular cron entry inside the scheduler container — add it to `[deployments.local.<name>.jobs.git-sync]` as in the example above. Running `bin/deploy <name> setup --git-sync` on a local deployment prints a reminder rather than installing anything.
+- **git-sync as a scheduler job.** On remote deployments, `--git-sync` installs a systemd timer out-of-band. On local deployments, git-sync runs as a regular cron entry inside the scheduler container — enable it via `bin/today configure` → Deployments → your deployment's jobs list, or add it to `[deployments.local.<name>.jobs.git-sync]` directly as in the example above. Running `bin/deploy <name> setup --git-sync` on a local deployment prints a reminder rather than installing anything.
 - **Resilio Sync is not supported** on local deployments (`--resilio` emits a warning and exits).
 - **Git push credentials inside the container**: the compose file bind-mounts `~/.ssh` read-only, so SSH URLs just work. If your vault remote is HTTPS, switch it: `cd <vault> && git remote set-url origin git@github.com:<user>/<vault>.git`. macOS Keychain credential helpers don't work inside a Linux container.
+- **Running `bin/deploy` from inside the devcontainer works**. The devcontainer installs the Docker CLI + Compose plugin and bind-mounts `/var/run/docker.sock` from the host, so `docker compose` commands from inside the devcontainer talk to the host's Docker daemon. The root `docker-compose.yml` uses `${HOST_PROJECT_PATH}` and `${HOST_HOME}` (set via `containerEnv` in `.devcontainer/devcontainer.json`) so bind mounts resolve against the real host filesystem rather than `/workspaces/today`. If Docker CLI isn't available in your shell, `bin/deploy` fails loudly with a copy-pasteable set of `docker compose` commands to run from a host terminal instead.
 
 ### Services & Jobs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: '3.3'
 
+# NOTE ON BIND-MOUNT PATHS
+#
+# `HOST_PROJECT_PATH` lets this compose file work both (a) from a shell on
+# the host, where `.` already resolves to the project root, and (b) from
+# inside the devcontainer, where `.` would resolve to /workspaces/today —
+# a path that only exists INSIDE the container, not on the host daemon
+# that actually creates the bind mounts. When run from inside the
+# devcontainer, `.devcontainer/devcontainer.json` sets HOST_PROJECT_PATH
+# from VS Code's ${localWorkspaceFolder}, so bind mounts get the real
+# host path the daemon can see. From a host shell, HOST_PROJECT_PATH is
+# unset and the `.` fallback works as before.
+#
+# Same pattern applies to `HOST_HOME` for ~/.ssh and ~/.config/claude.
+
 services:
   today:
     build: .
@@ -10,15 +24,15 @@ services:
       - OLLAMA_HOST=http://ollama:11434
     volumes:
       # Mount the entire project directory
-      - .:/app
+      - ${HOST_PROJECT_PATH:-.}:/app
       # Use named volumes for caches to persist between container rebuilds
       - calendar-cache:/app/.calendar-cache
       # Override node_modules to use container's version
       - /app/node_modules
       # Mount SSH directory for git operations (read-only)
-      - ~/.ssh:/root/.ssh:ro
+      - ${HOST_HOME:-~}/.ssh:/root/.ssh:ro
       # Mount Claude CLI config directory for authentication persistence
-      - ~/.config/claude:/root/.config/claude
+      - ${HOST_HOME:-~}/.config/claude:/root/.config/claude
     stdin_open: true
     tty: true
     depends_on:
@@ -42,10 +56,10 @@ services:
       - SKIP_DEP_CHECK=true
       - OLLAMA_HOST=http://ollama:11434
     volumes:
-      - .:/app
+      - ${HOST_PROJECT_PATH:-.}:/app
       - calendar-cache:/app/.calendar-cache
       - /app/node_modules
-      - ~/.ssh:/root/.ssh:ro
+      - ${HOST_HOME:-~}/.ssh:/root/.ssh:ro
     restart: unless-stopped
     depends_on:
       - ollama

--- a/src/deploy/commands/deploy.js
+++ b/src/deploy/commands/deploy.js
@@ -292,15 +292,52 @@ async function deployLocal(server) {
     .filter(([_, enabled]) => enabled)
     .map(([name]) => name === 'scheduler' ? 'today-scheduler' : name);
 
+  const startedServices = [];
+  const failedServices = [];
+
   if (enabledServices.length > 0) {
+    // Pre-flight: make sure docker is actually available on this machine.
+    // If it isn't (common when running `bin/deploy` from inside a
+    // devcontainer without docker CLI installed), we fail loudly instead
+    // of pretending the services started.
+    const dockerCheck = server.sshCmd('command -v docker >/dev/null 2>&1', { check: false });
+    if (dockerCheck.returncode !== 0) {
+      printError('Docker CLI not found — cannot bring up compose services from this shell.');
+      console.log('');
+      console.log('The scheduler-config.json and deployment-name files have been written,');
+      console.log('but services were not started. Run these from a shell that has docker:');
+      console.log('');
+      console.log(`  cd ${deployPath}`);
+      for (const service of enabledServices) {
+        const bare = service === 'today-scheduler' ? 'scheduler' : service;
+        console.log(`  docker compose up -d ${bare}`);
+      }
+      console.log('');
+      console.log('If you are inside a devcontainer, either run this from the host shell, or');
+      console.log('rebuild the devcontainer with Docker CLI installed and /var/run/docker.sock mounted.');
+      process.exit(1);
+    }
+
     printInfo(`Starting configured services: ${enabledServices.join(', ')}`);
     for (const service of enabledServices) {
       // `enable` + `restart` both map to compose commands; restart handles
       // the "already running, pick up new config" case.
-      server.systemctl('enable', service, { check: false });
-      server.systemctl('restart', service, { check: false });
+      const enableResult = server.systemctl('enable', service, { check: false });
+      const restartResult = server.systemctl('restart', service, { check: false });
+      if (enableResult.returncode === 0 && restartResult.returncode === 0) {
+        startedServices.push(service);
+      } else {
+        failedServices.push(service);
+      }
     }
-    printStatus(`Started ${enabledServices.length} service(s)`);
+    if (startedServices.length > 0) {
+      printStatus(`Started ${startedServices.length} service(s): ${startedServices.join(', ')}`);
+    }
+    if (failedServices.length > 0) {
+      printError(`Failed to start ${failedServices.length} service(s): ${failedServices.join(', ')}`);
+      console.log('  Investigate with: docker compose logs <service>');
+      process.exit(1);
+    }
   } else {
     printInfo('No services configured. Enable in config.toml under [deployments.local.*.services]');
   }
@@ -308,8 +345,8 @@ async function deployLocal(server) {
   printStatus('Local deployment complete!');
   console.log('');
   console.log(`  Deploy path: ${deployPath}`);
-  if (enabledServices.length > 0) {
-    console.log(`  Services:    ${enabledServices.join(', ')}`);
+  if (startedServices.length > 0) {
+    console.log(`  Services:    ${startedServices.join(', ')}`);
     console.log(`  Logs:        docker compose logs -f <service>`);
   }
 }

--- a/src/deployments-configure-ui.js
+++ b/src/deployments-configure-ui.js
@@ -36,6 +36,13 @@ const PREDEFINED_JOBS = [
     description: 'Sync all plugins every 10 minutes',
     schedule: '*/10 * * * *',
     command: 'bin/plugins sync'
+  },
+  {
+    key: 'git-sync',
+    label: 'Git Sync (vault)',
+    description: 'Pull/rebase/push the vault via git every minute (for local deployments)',
+    schedule: '* * * * *',
+    command: 'bin/git-sync'
   }
 ];
 


### PR DESCRIPTION
## Summary

Three fixes from the first real Mac test of the local deployment provider (#199):

1. **`bin/today configure` didn't offer git-sync as a toggleable job.** Only plugin-sync was in `PREDEFINED_JOBS`, so the only way to enable git-sync on a local deployment was hand-editing config.toml. Adds git-sync to the list.

2. **`bin/deploy <local-name>` lied about success** when Docker wasn't available. All four `docker compose up -d` calls failed silently (docker not in PATH inside the devcontainer), then the code printed "✓ Started 2 service(s)" anyway. Fix tracks actual success/failure per service, adds a pre-flight `command -v docker` check with a copy-pasteable fallback, and exits non-zero on any failure.

3. **Running `bin/deploy` from inside the devcontainer didn't work** because the devcontainer image didn't include Docker CLI. Installs `docker-ce-cli` + `docker-compose-plugin` in the devcontainer Dockerfile, bind-mounts `/var/run/docker.sock` from the host, and threads `HOST_PROJECT_PATH` + `HOST_HOME` through so compose bind mounts resolve to real host paths instead of `/workspaces/today` when run from inside the devcontainer. This is the standard docker-outside-of-docker pattern.

## Changes

### Configure UI
- **`src/deployments-configure-ui.js`** — `PREDEFINED_JOBS` now includes `git-sync` alongside `plugin-sync`, with a description flagging that it's for local deployments.

### Deploy command safety
- **`src/deploy/commands/deploy.js`** — `deployLocal()`:
  - Pre-flight `command -v docker` check; if missing, prints a clear error with the exact fallback commands to run from a host shell, then exits 1.
  - Tracks `startedServices` / `failedServices` separately and only reports what actually worked; exits 1 if any service failed.

### Devcontainer enablement
- **`.devcontainer/Dockerfile`** — installs Docker CLI and Compose plugin from Docker's APT repo.
- **`.devcontainer/docker-compose.yml`** — bind-mounts `/var/run/docker.sock` into the devcontainer so docker commands talk to the host daemon.
- **`.devcontainer/devcontainer.json`** — sets `HOST_PROJECT_PATH` and `HOST_HOME` in `containerEnv` via `${localWorkspaceFolder}` / `${localEnv:HOME}`, so those are available to any compose invocation from inside the devcontainer.
- **`docker-compose.yml`** — bind mounts now use `${HOST_PROJECT_PATH:-.}:/app` and `${HOST_HOME:-~}/.ssh:/root/.ssh:ro` (same pattern for `~/.config/claude`). From a host shell the variables are unset and the `.` / `~` fallbacks work as before; from inside the devcontainer the host paths are used so the host daemon can actually find the files.

### Docs
- **`README.md`** — documents the devcontainer flow and points users at `bin/today configure` as the preferred way to enable git-sync on a local deployment.

## Test plan

- [x] `node --check` all edited JS files
- [x] YAML parse of root `docker-compose.yml`
- [x] `jest test/deploy-config.test.js` — 12 passing
- [ ] **Not yet exercised** (you'll drive): `bin/deploy macbook` from inside the Mac devcontainer after rebuilding it, with git-sync toggled on via `bin/today configure`. Expected: scheduler service comes up, mounts the host project and ~/.ssh, picks up `.data/scheduler-config.json`, git-sync fires on the next cron tick.

## Gotcha worth noting

Rebuilding the devcontainer is required to get the Docker CLI + socket mount in place. In VS Code: Command Palette → "Dev Containers: Rebuild Container". Without that, the fix for #3 doesn't take effect (but the fixes for #1 and #2 still work from a host shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)