### PR TITLE
chore: drop Turso CLI install from Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,15 +9,6 @@ RUN apt-get update && apt-get install -y python3 make g++ sqlite3 curl && rm -rf
 # handles /var/run/docker.sock group permissions correctly, which a manual
 # Dockerfile install does not. Don't duplicate it here.
 
-# Install Turso CLI manually (avoid auto-auth issues)
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; fi && \
-    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then ARCH="arm64"; fi && \
-    curl -sSfL "https://github.com/tursodatabase/turso-cli/releases/latest/download/turso-cli_Linux_$ARCH.tar.gz" | \
-    tar -xz -C /tmp && \
-    mv /tmp/turso /usr/local/bin/turso && \
-    chmod +x /usr/local/bin/turso
-
 # Install CLI tools: ripgrep, fd-find, bat, ruby (for mdless)
 RUN apt-get update && apt-get install -y ripgrep fd-find bat ruby ruby-dev && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ WORKDIR /app
 # Install build dependencies for native modules, curl, sqlite, bash, git, and GitHub CLI
 RUN apk add --no-cache python3 make g++ curl sqlite bash git github-cli
 
-# Install Turso CLI
-RUN curl -sSfL https://get.tur.so/install.sh | bash && \
-    mv /root/.turso/bin/turso /usr/local/bin/turso
-
 # Copy package files
 COPY package*.json ./
 

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -65,7 +65,7 @@ const __dirname = dirname(__filename);
 const DEBUG = process.env.DEBUG === 'true';
 const debug = (...args) => DEBUG && console.log('[DEBUG]', ...args);
 
-// Web server only needs read-only access, disable Turso sync for faster startup
+// Web server only needs read-only access, disable auto-sync for faster startup
 const getReadOnlyDatabase = () => getDatabase('.data/today.db', { autoSync: false });
 
 const app = express();


### PR DESCRIPTION
## Summary

Today no longer uses Turso, but both Dockerfiles still tried to install the Turso CLI at image build time. The upstream installer script has also changed its layout — the CLI now lands at \`/root/.turso/\` directly rather than \`/root/.turso/bin/\`, so the \`mv /root/.turso/bin/turso ...\` step in the root Dockerfile fails with "No such file or directory" and **aborts every \`docker compose build\`** for the scheduler / vault-web / vault-watcher / inbox-api services added in #202.

This was caught immediately by the first Mac run of \`bin/deploy macbook\` after rebuilding the devcontainer from #201+#202: the local provider tried to build the \`today-scheduler\` and \`today-vault-web\` images, and both failed on the Turso install step.

## Changes

- **\`Dockerfile\`**: drop the Turso install \`RUN\`.
- **\`.devcontainer/Dockerfile\`**: drop the Turso release-download \`RUN\` and its arch-detection logic.
- **\`src/web-server.js\`**: update a stale comment that referenced "Turso sync" — the \`autoSync\` flag is a generic database option now, not Turso-specific.

## Why this is safe

Repo-wide grep for \`turso\` / \`libsql\` / \`Turso\`:

\`\`\`
src/web-server.js   (the stale comment, fixed in this PR)
Dockerfile          (the install step, removed)
.devcontainer/Dockerfile (the install step, removed)
\`\`\`

No runtime code references Turso. No package.json dependencies. The \`.data/turso-sync.json\` file that exists on deployed instances is a stale state file; it's not read by any current code.

## Test plan

- [x] \`node --check src/web-server.js\`
- [x] Repo-wide grep confirms no runtime Turso usage
- [ ] **Next step on the Mac**: re-run \`bin/deploy macbook\` — image build should now complete and the scheduler + vault-web containers should come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)