### PR TITLE
fix(docker): add Cairo/Pango dev libs so canvas builds on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,15 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install build dependencies for native modules, curl, sqlite, bash, git, and GitHub CLI
-RUN apk add --no-cache python3 make g++ curl sqlite bash git github-cli
+# Install build dependencies for native modules, curl, sqlite, bash, git, GitHub CLI,
+# and the Cairo/Pango/etc stack required by the `canvas` package (used by the
+# data-graphing plugin). pkgconfig + *-dev packages are needed because we build
+# canvas from source in the next layer — prebuilt binaries aren't published for
+# Alpine/musl on ARM64.
+RUN apk add --no-cache \
+    python3 make g++ pkgconfig \
+    curl sqlite bash git github-cli \
+    cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
 
 # Copy package files
 COPY package*.json ./


### PR DESCRIPTION
## Summary

Another round of "first Mac devcontainer run exposed a thing." With Turso removed (#203), the next layer to fail was `npm install --build-from-source` dying on the `canvas` package:

\`\`\`
npm error /bin/sh: pkg-config: not found
npm error gyp: Call to 'pkg-config pixman-1 --libs' returned exit status 127
\`\`\`

The root \`Dockerfile\`'s \`apk add\` line doesn't include pkg-config or the dev headers for the Cairo/Pango stack that \`canvas\` depends on, so node-gyp can't build it from source. Prebuilt binaries for \`canvas\` aren't published for Alpine/musl/ARM64, so build-from-source is the only path.

## Why this hasn't bitten before

The droplet doesn't build this image — it runs Today directly from the git checkout on the host (systemd services call \`node src/...\`). The Mac devcontainer is the first place \`docker compose build\` actually runs against the root Dockerfile, and its first build target on Apple Silicon is Alpine/ARM64 — a combo nobody had exercised until now.

## Changes

- **\`Dockerfile\`**: add \`pkgconfig\` + \`cairo-dev\` + \`pango-dev\` + \`jpeg-dev\` + \`giflib-dev\` + \`librsvg-dev\` to the first \`apk add\` layer. Preserves \`--build-from-source\` so \`better-sqlite3\` and other native modules still get proper rebuilds.

## Alternatives considered

- **Drop \`--build-from-source\`** — would let packages use prebuilt binaries where available. Works for \`better-sqlite3\` but not for \`canvas\` on Alpine ARM64 (no prebuilds for that triple). Doesn't actually fix anything here.
- **Move \`canvas\` to \`optionalDependencies\`** — npm would skip it silently if build fails. Smaller images, but silently disables the data-graphing plugin, and a future "why isn't my graph working?" investigation would be annoying. Save for later if image size becomes a problem.

## Test plan

- [x] Inspect the diff — just a package list change
- [ ] **Next step on the Mac**: pull this and re-run \`bin/deploy macbook\`. Expected: \`npm install\` completes, image build finishes, scheduler + vault-web containers come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)