### PR TITLE
fix(local-deploy): respect mounts.local for the vault bind mount

### DIFF
--- a/.devcontainer/generate-compose-override.sh
+++ b/.devcontainer/generate-compose-override.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
-# Generate docker-compose.override.yml from mounts.local
-# Runs on the HOST before container build (via initializeCommand)
+# Generate docker-compose.override.yml files from mounts.local.
+# Runs on the HOST before container build (via initializeCommand).
+#
+# Produces TWO override files:
+#
+# 1. .devcontainer/docker-compose.override.yml — extra bind mounts for the
+#    devcontainer itself, so you can edit your real vault / other project
+#    directories from inside the devcontainer at /workspaces/today/<name>.
+#
+# 2. docker-compose.override.yml (at the project root) — bind mount for the
+#    `vault` entry (only), applied to the today / scheduler / vault-web /
+#    vault-watcher / inbox-api services so that `bin/deploy <local-name>`
+#    runs them against your REAL vault instead of whatever is at
+#    ./vault on the host project path. Compose auto-merges this with the
+#    root docker-compose.yml.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 MOUNTS_FILE="$SCRIPT_DIR/mounts.local"
 OVERRIDE_FILE="$SCRIPT_DIR/docker-compose.override.yml"
+ROOT_OVERRIDE_FILE="$PROJECT_ROOT/docker-compose.override.yml"
 
 if [ ! -f "$MOUNTS_FILE" ]; then
     echo "No mounts.local found - skipping override generation"
-    rm -f "$OVERRIDE_FILE"
+    rm -f "$OVERRIDE_FILE" "$ROOT_OVERRIDE_FILE"
     exit 0
 fi
 
@@ -49,9 +64,59 @@ done < "$MOUNTS_FILE"
 
 echo "Override file generated: $OVERRIDE_FILE"
 
+# Find the vault mount (if any) and generate the root-level override so the
+# Mac local-deployment compose services (scheduler, vault-web, etc.) bind the
+# same real vault directory as the devcontainer instead of whatever is at
+# ./vault on the project path.
+VAULT_SRC=""
+while IFS= read -r line || [ -n "$line" ]; do
+    [[ "$line" =~ ^#.*$ ]] && continue
+    [[ -z "$line" ]] && continue
+    target="${line%%=*}"
+    source="${line#*=}"
+    target="$(echo "$target" | xargs)"
+    source="$(echo "$source" | xargs)"
+    if [ "$target" = "vault" ] && [ -e "$source" ]; then
+        VAULT_SRC="$source"
+        break
+    fi
+done < "$MOUNTS_FILE"
+
+if [ -n "$VAULT_SRC" ]; then
+    cat > "$ROOT_OVERRIDE_FILE" << EOF
+# Auto-generated from .devcontainer/mounts.local - do not edit manually.
+#
+# Overrides the vault bind mount for services that need vault access so they
+# point at the real host vault directory (from mounts.local) instead of
+# whatever the root docker-compose.yml would resolve ./vault to. Without this
+# override, bin/deploy <local-name> would run against a stale or empty
+# ./vault directory on the host filesystem.
+services:
+  today:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
+  scheduler:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
+  vault-web:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
+  vault-watcher:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
+  inbox-api:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
+EOF
+    echo "Root override file generated: $ROOT_OVERRIDE_FILE (vault -> $VAULT_SRC)"
+else
+    # No vault mount configured in mounts.local — remove any stale root
+    # override so compose falls back to the default ./vault behavior.
+    rm -f "$ROOT_OVERRIDE_FILE"
+fi
+
 # Also generate .git/info/exclude to ignore mounted directories
 # Use leading slashes so only top-level directories are ignored (not plugin subdirs)
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 EXCLUDE_FILE="$PROJECT_ROOT/.git/info/exclude"
 
 if [ -d "$PROJECT_ROOT/.git/info" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ __pycache__/
 # =============================================================================
 .devcontainer/mounts.local
 .devcontainer/docker-compose.override.yml
+# Root-level docker-compose override is auto-generated from
+# .devcontainer/mounts.local by generate-compose-override.sh and points
+# the local-deployment compose services at the user's real vault.
+/docker-compose.override.yml
 
 # =============================================================================
 # OS Files


### PR DESCRIPTION
## Summary

The first real run of `bin/deploy macbook` against a non-trivial Mac setup hit one more architectural mismatch: the user's real vault lives in iCloud (`~/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault`), not under the Today project. The devcontainer handles this via `.devcontainer/mounts.local` → auto-generated `.devcontainer/docker-compose.override.yml`, so `/workspaces/today/vault` inside the devcontainer correctly resolves to the iCloud path.

But the **root** `docker-compose.yml` (which the scheduler / vault-web / etc compose services use) knew nothing about the overlay. It bind-mounted `/app/vault` from whatever the host project path happened to have at `./vault` — which was a stale Jan 10 snapshot with no `.git`. git-sync inside the scheduler then walked up to the Today project's `.git` and tried to use its HTTPS remote, hence the username prompt we saw.

## The diagnosis, for the record

From the scheduler container:

```
$ docker compose exec scheduler sh -c 'ls -la /app/vault | head'
drwxr-xr-x 3 root root  96 Jan 10 15:08 .obsidian
drwxr-xr-x 3 root root  96 Jan 10 15:08 inbox
drwxr-xr-x 3 root root  96 Jan 10 15:08 plans
...
$ docker compose exec scheduler sh -c 'cd /app/vault && git remote -v'
origin  https://github.com/jeffcovey/today.git     # ← today's remote, not vault.git
```

The `Jan 10` mtimes were the giveaway — that directory hadn't been touched in months because the real vault is elsewhere.

## Fix

Extend `.devcontainer/generate-compose-override.sh` (the same script that already handles `.devcontainer/mounts.local`) to ALSO emit a **root-level** `docker-compose.override.yml` when `mounts.local` contains a `vault=...` entry. The root override adds a bind mount for the real vault path at `/app/vault` in all services that need vault access (today, scheduler, vault-web, vault-watcher, inbox-api). Docker compose auto-merges files named `docker-compose.override.yml`, so `bin/deploy <name>` picks it up with no command or CLI changes.

If `mounts.local` is missing or doesn't have a `vault=` entry, the script removes the root override (same graceful-degrade pattern as the devcontainer override).

## Changes

- **`.devcontainer/generate-compose-override.sh`** — after emitting the devcontainer override, scan `mounts.local` for a `vault=` entry and emit a root-level `docker-compose.override.yml` with bind mounts for the 5 compose services. If no vault entry, remove any stale override.
- **`.gitignore`** — add `/docker-compose.override.yml` so the generated file is never committed. Matches the existing `.devcontainer/docker-compose.override.yml` entry.

## Example output

With Jeff's `mounts.local`:

```
vault=/Users/jeff/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault
OlderGay.Men=/Users/jeff/src/rails/OlderGay.Men
```

The generated root-level `docker-compose.override.yml` is:

```yaml
services:
  today:
    volumes:
      - "/Users/jeff/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault:/app/vault:cached"
  scheduler:
    volumes:
      - "/Users/jeff/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault:/app/vault:cached"
  # ...vault-web, vault-watcher, inbox-api all the same
```

## Test plan

- [x] Bash syntax check on the edited script
- [x] Dry-run the updated script against a fake `mounts.local` and inspect the generated override file — it matches the expected format exactly
- [ ] **Next step on the Mac**: pull, rebuild the devcontainer (so `initializeCommand` triggers the script on the HOST), then `docker compose down && bin/deploy macbook`. Expected: scheduler's `/app/vault` now points at the iCloud vault, `git remote -v` inside it returns the SSH vault remote, and `bin/git-sync` runs cleanly without prompting.

## Notes

- The script only runs on the **host** (as `initializeCommand`), not inside the devcontainer — it needs access to host paths that don't exist inside the container. Rebuilding the devcontainer is what triggers it.
- After rebuild, `docker compose down && bin/deploy macbook` is needed to recreate the scheduler container with the new bind mount. Docker doesn't re-read override files for already-running containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)