### PR TITLE
fix(docker): install openssh-client so git can use SSH remotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Install build dependencies for native modules, curl, sqlite, bash, git, GitHub CLI,
+# openssh-client (needed by git for SSH remotes — git-sync pushes to git@github.com:...),
 # and the Cairo/Pango/etc stack required by the `canvas` package (used by the
 # data-graphing plugin). pkgconfig + *-dev packages are needed because we build
 # canvas from source in the next layer — prebuilt binaries aren't published for
 # Alpine/musl on ARM64.
 RUN apk add --no-cache \
     python3 make g++ pkgconfig \
-    curl sqlite bash git github-cli \
+    curl sqlite bash git openssh-client github-cli \
     cairo-dev pango-dev jpeg-dev giflib-dev librsvg-dev
 
 # Copy package files


### PR DESCRIPTION
## Summary

The root \`Dockerfile\`'s \`apk add\` installs \`git\` but not \`openssh-client\`. On Alpine, git needs to exec \`ssh\` for any remote URL starting with \`git@...\`. Without the ssh binary:

\`\`\`
error: cannot run ssh: No such file or directory
fatal: unable to fork
\`\`\`

This was the last remaining blocker for \`bin/git-sync\` inside the Mac-local scheduler container. With #205's vault bind mount in place, git-sync finally reached the SSH remote, tried to fork \`ssh\`, and failed silently because the binary wasn't installed.

## Diagnosis from the Mac devcontainer

\`\`\`
$ docker compose exec scheduler bin/git-sync; echo "exit: $?"
exit: 2

$ docker compose exec scheduler cat /var/log/git-sync.log
2026-04-15T23:26:00.109Z ERROR pull failed: error: cannot run ssh: No such file or directory
fatal: unable to fork
...

$ docker compose exec scheduler sh -c 'cd /app/vault && git fetch origin 2>&1'
error: cannot run ssh: No such file or directory
fatal: unable to fork
\`\`\`

## Changes

- **\`Dockerfile\`**: add \`openssh-client\` to the \`apk add\` line. A few MB, no new runtime config — the container already bind-mounts the host's \`~/.ssh\` read-only via the same pattern HOST_HOME/\`HOST_PROJECT_PATH\` threading we set up in earlier PRs.

## Test plan

- [x] Diff is a single-line addition
- [ ] **Next step on the Mac**: pull, rebuild the images (\`bin/deploy macbook\` re-runs compose build), then \`docker compose exec scheduler bin/git-sync; echo "exit: $?"\`. Expected: exit 0, clean sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)