### PR TITLE
fix(deploy): don't uninstall opt-in systemd units on regular deploys

### DIFF
--- a/src/deploy/commands/deploy.js
+++ b/src/deploy/commands/deploy.js
@@ -207,10 +207,31 @@ async function installServices(server) {
 }
 
 /**
- * Remove systemd services that reference our deploy path but no longer have templates
+ * Remove systemd services that reference our deploy path but no longer have templates.
+ *
+ * "Known" services come from two places in the repo:
+ *
+ *   - config/services/*.service — always-installed services (the set passed in
+ *     as `currentServiceFiles` from installServices).
+ *   - deploy/systemd/*.service — opt-in services installed out-of-band by
+ *     setup hooks like setupGitSync(). These are NOT installed by the regular
+ *     deploy path, but they ARE expected to persist across deploys once a
+ *     user has opted in via `bin/deploy <name> setup --git-sync` etc.
+ *
+ * Without counting `deploy/systemd/` here, regular `bin/deploy <name>` silently
+ * uninstalls git-sync.service every run, which orphans git-sync.timer and
+ * breaks vault sync until the healthcheck catches up 10 minutes later.
  */
 async function cleanupStaleServices(server, currentServiceFiles) {
   const deployPath = server.deployPath;
+
+  // Expand the "don't remove" set to also include opt-in units from
+  // deploy/systemd/, so regular deploys preserve them.
+  const optionalServicesDir = path.join(PROJECT_ROOT, 'deploy', 'systemd');
+  const optionalServiceFiles = fs.existsSync(optionalServicesDir)
+    ? fs.readdirSync(optionalServicesDir).filter(f => f.endsWith('.service'))
+    : [];
+  const knownServiceFiles = [...currentServiceFiles, ...optionalServiceFiles];
 
   // Find all .service files on the server that reference our deploy path
   const result = server.sshCmd(
@@ -225,7 +246,7 @@ async function cleanupStaleServices(server, currentServiceFiles) {
 
   if (remoteServices.length === 0) return;
 
-  const staleServices = remoteServices.filter(f => !currentServiceFiles.includes(f));
+  const staleServices = remoteServices.filter(f => !knownServiceFiles.includes(f));
 
   if (staleServices.length === 0) return;
 


### PR DESCRIPTION
## Summary

Closes #211.

`cleanupStaleServices()` in `src/deploy/commands/deploy.js` considered only `config/services/*.service` as the set of "known" units to preserve. Any `.service` file on the remote that referenced the deploy path but wasn't in that set was removed — including units installed out-of-band by setup hooks like `setupGitSync()`, which ships its files from `deploy/systemd/`.

Result: every regular `bin/deploy <remote>` silently uninstalled `git-sync.service`, orphaning `git-sync.timer` with `Failed to queue unit startup job: Unit git-sync.service not found` on the next tick. The healthcheck from #198 caught it 10 minutes later via the `vault/.sync-status.md` marker, but by then vault sync had been broken for at least that long.

## Change

Expand the "don't remove" set in `cleanupStaleServices()` to also include `deploy/systemd/*.service`:

\`\`\`js
const optionalServicesDir = path.join(PROJECT_ROOT, 'deploy', 'systemd');
const optionalServiceFiles = fs.existsSync(optionalServicesDir)
  ? fs.readdirSync(optionalServicesDir).filter(f => f.endsWith('.service'))
  : [];
const knownServiceFiles = [...currentServiceFiles, ...optionalServiceFiles];
\`\`\`

Then `staleServices` is filtered against `knownServiceFiles` instead of `currentServiceFiles`.

## Why this shape

- Units in `config/services/` are "always installed" on every deploy.
- Units in `deploy/systemd/` are "opt-in" — installed by `setup --git-sync` (and potentially other future setup hooks), expected to persist across code-only deploys.
- The cleanup still removes genuinely stale units (anything that references the deploy path but exists in neither directory), so the original "prune old services" intent is preserved.

## Test plan

- [x] `node --check` passes
- [ ] **Next run of `bin/deploy droplet`**: `systemctl is-active git-sync.timer` should still return `active` afterward. Previously this would have returned `failed`.
- [ ] The actual droplet test: wait until the next `bin/deploy droplet` happens naturally (or force one), verify the git-sync.timer survives.

## Related

- #197 / #198 / #199 — git-sync introduction and healthcheck
- #201 / #202 / #203 / #204 / #205 / #206 — Mac-local-deployment rollout
- #211 — the bug this fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)