### PR TITLE
fix: add vault-watcher to configure UI and deploy config parsing

### DIFF
--- a/src/deploy/config.js
+++ b/src/deploy/config.js
@@ -128,6 +128,7 @@ export function getDeployments() {
       const servicesConfig = deploymentConfig.services || {};
       const services = {
         scheduler: servicesConfig.scheduler === true,
+        'vault-watcher': servicesConfig['vault-watcher'] === true,
         'vault-web': servicesConfig['vault-web'] === true,
         'inbox-api': servicesConfig['inbox-api'] === true,
         'resilio-sync': servicesConfig['resilio-sync'] === true,

--- a/src/deployments-configure-ui.js
+++ b/src/deployments-configure-ui.js
@@ -266,7 +266,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
 
     // Services mode
     if (mode === 'services') {
-      const serviceKeys = ['scheduler', 'inbox-api', 'vault-web', '__back__'];
+      const serviceKeys = ['scheduler', 'vault-watcher', 'inbox-api', 'vault-web', '__back__'];
       if (key.escape || input === 'q') {
         setMode('edit');
         setServiceIndex(0);
@@ -667,6 +667,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
     const services = selected.services || {};
     const servicesList = [
       { key: 'scheduler', label: 'Scheduler', desc: 'Run scheduled jobs' },
+      { key: 'vault-watcher', label: 'Vault Watcher', desc: 'Auto-commit vault changes as they happen' },
       { key: 'inbox-api', label: 'Inbox API', desc: 'Receive uploads from mobile' },
       { key: 'vault-web', label: 'Vault Web', desc: 'Serve vault as static site' },
     ];
@@ -765,6 +766,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
     const services = selected.services || {};
     const servicesList = [
       { key: 'scheduler', label: 'Scheduler', desc: 'Run scheduled jobs' },
+      { key: 'vault-watcher', label: 'Vault Watcher', desc: 'Auto-commit vault changes as they happen' },
       { key: 'inbox-api', label: 'Inbox API', desc: 'Receive uploads from mobile' },
       { key: 'vault-web', label: 'Vault Web', desc: 'Serve vault as static site' },
     ];


### PR DESCRIPTION
## Summary

The Services pane in `bin/today configure` was hardcoded to offer only scheduler, inbox-api, and vault-web, even though `vault-watcher` has been a first-class systemd service, compose service, and deploy-managed service for a while. Also adds it to `src/deploy/config.js`'s services map (same omission).

Users can now enable vault-watcher on a deployment through the UI, and it gets written to config.toml and picked up by `bin/deploy`.

## Changes

- **`src/deployments-configure-ui.js`** — add `vault-watcher` to:
  - the `serviceKeys` array used for keyboard navigation in the services mode
  - both `servicesList` arrays used for rendering (edit pane preview and services mode detail view)
- **`src/deploy/config.js`** — add `'vault-watcher': servicesConfig['vault-watcher'] === true` to the services parsing map.

## Not fixed in this PR (filed separately)

The root cause — the list of services is smeared across at least six files (`config/services/*.service`, `src/deployments-configure-ui.js`, `src/deploy/config.js`, `src/deploy/commands/services.js`, `src/deploy/providers/local.js`, `docker-compose.yml`) with subtly different contents — is tracked as a follow-up refactor. This PR is the minimal change to unblock enabling vault-watcher via the UI.

## Test plan

- [x] `node --check` passes on both files
- [x] `jest test/deploy-config.test.js` — 12 tests pass
- [ ] **Next step on the Mac**: `bin/today configure` → Deployments → macbook → Services. vault-watcher should appear as a toggleable option. Enabling it and running `bin/deploy macbook` should write `vault-watcher = true` to config.toml and start the `vault-watcher` compose service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)