### PR TITLE
fix(local-deploy): auto-rebuild images and remove wrong vault-web port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,15 @@ Many file-based plugins look for a "vault" directory and follow some [Obsidian](
 
 **Important:** The `vault/` directory is gitignored because it contains personal data. Initialize it as a separate repository or sync it with your preferred solution. Plugins have permission to read and write from the vault. We *strongly suggest* you run `git init` within the vault and monitor its changes to make sure you're happy with any changes `today` makes.
 
-For multi-device sync, Today supports two built-in options on remote deployments (see `bin/deploy <name> setup --git-sync` or `--resilio`):
+Multi-device vault sync has two distinct layers:
 
-- **git-sync** (recommended): a systemd timer pulls/rebases/pushes the vault against its git remote every ~60s. No background daemon, no opaque state — conflicts surface as normal git rebase failures and get resolved on whichever peer introduced them. Requires the vault to be a git checkout with push credentials configured.
-- **Resilio Sync**: peer-to-peer sync via the Resilio daemon. Realtime and requires no git setup, but introduces a stateful daemon with its own sync metadata. Make sure `.git`, `.git.nosync`, and `node_modules` are in the share's IgnoreList before adding the folder — unignored git directories will flood the daemon.
+**Working-tree sync** (the files themselves) keeps the vault's actual file contents identical across devices. When you edit a file on one device, the change appears on all other devices — uncommitted, unstaged, just the raw bytes. Use any file-level sync tool you prefer: Resilio Sync, Syncthing, iCloud, Dropbox, Unison, etc. Make sure `.git`, `.git.nosync`, and `node_modules` are excluded from the sync — unignored git directories will flood most sync daemons with inotify events.
 
-You can also use any external sync you already run (Syncthing, iCloud, Dropbox, etc.); those don't need integration with Today.
+**Committed-state sync** (git history) keeps each device's git repository in sync so that commits made on one device are available on all others. This is separate from working-tree sync — git can only push and pull *commits*, not uncommitted changes:
+
+- **git-sync**: a timer (systemd on remote deployments, scheduler cron on local) that runs `git pull --rebase --autostash && git push` every ~60s. When you commit on one device, git-sync pushes the commit to GitHub; on other devices, git-sync pulls it and fast-forwards HEAD. Working-tree content doesn't change (it was already in sync via the file-sync layer), but the git log and staging area update to reflect the new commit. Install via `bin/deploy <name> setup --git-sync` (remote) or add it as a scheduler job in `bin/today configure` (local).
+
+**Important:** git-sync does NOT create commits and does NOT sync uncommitted changes. Commits are always manual. If you only set up git-sync without a working-tree sync tool, files edited on one device will not appear on other devices until you commit and push.
 
 ---
 

--- a/bin/git-sync
+++ b/bin/git-sync
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 
 /**
- * Sync the vault with its git remote via pull --rebase + push.
+ * Sync COMMITTED git state between this device and the vault's remote.
  *
- * Designed to run from a systemd timer (Linux) or launchd agent (macOS)
- * every ~60s. Exits non-zero on error so the supervisor reports failure;
- * the next scheduled run retries automatically.
+ * This script handles the "committed-state" layer of vault sync:
+ *   - Pulls new commits from origin (via rebase, so local commits replay cleanly)
+ *   - Pushes any local commits to origin
+ *
+ * It does NOT create commits. It does NOT sync uncommitted working-tree
+ * changes. Commits are always a manual, deliberate act by the user.
+ * Uncommitted file-level sync between devices is handled separately by
+ * a working-tree sync tool (Unison, Resilio, iCloud, etc.).
+ *
+ * Designed to run from a systemd timer (Linux) or as a scheduler cron
+ * job (local/Docker deployments) every ~60s. Exits non-zero on error so
+ * the supervisor reports failure; the next scheduled run retries.
  *
  * The vault path is read from config.toml via getAbsoluteVaultPath().
  * The log path can be overridden with GIT_SYNC_LOG; default is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
     restart: unless-stopped
 
   # Runs node src/web-server.js — the vault web UI.
+  # No port mapping here — WEB_PORT is user-configured (encrypted in .env,
+  # decrypted by dotenvx at runtime) so compose can't know it at parse time.
+  # VS Code auto-forwards the port when it detects the server listening.
   vault-web:
     build: .
     container_name: today-vault-web
@@ -77,8 +80,6 @@ services:
       - ${HOST_PROJECT_PATH:-.}:/app
       - calendar-cache:/app/.calendar-cache
       - /app/node_modules
-    ports:
-      - "8082:8082"
     restart: unless-stopped
 
   # Runs node src/vault-watcher.js — real-time file change watcher.

--- a/src/deploy/providers/local.js
+++ b/src/deploy/providers/local.js
@@ -170,7 +170,10 @@ export class LocalProvider extends RemoteServer {
     switch (action) {
       case 'start':
       case 'enable':
-        cmd = `docker compose up -d ${svc}`;
+        // Always pass --build so Dockerfile changes (new apk packages,
+        // new binaries, etc.) are picked up automatically. Docker caches
+        // unchanged layers, so this is fast when nothing changed.
+        cmd = `docker compose up -d --build ${svc}`;
         break;
       case 'stop':
       case 'disable':


### PR DESCRIPTION
Closes #207.

## 1. Auto-rebuild images on deploy

`LocalProvider.systemctl('enable')` now passes `--build` to `docker compose up -d`, so Dockerfile changes are picked up automatically. Docker caches unchanged layers (fast no-op when nothing changed), but this stops the "deployed new code, container still runs old image" trap that cost us 3 debug cycles during the Mac rollout.

## 2. vault-web port mapping removed

The old mapping `8082:8082` was wrong — it matched nothing. Removed entirely rather than guessing a new value, because WEB_PORT is user-configured (encrypted in `.env`, decrypted by dotenvx at runtime inside the container) so compose can't know it at parse time. VS Code auto-forwards the port when it detects the server listening, so explicit mapping isn't needed for devcontainer users.

The droplet is unaffected — it runs vault-web via systemd, not docker-compose.

## Test plan
- [x] Syntax checks + YAML parse + deploy-config tests pass
- [ ] Next `bin/deploy macbook`: should see `Building` output on first run after a Dockerfile change

🤖 Generated with [Claude Code](https://claude.com/claude-code)