### PR TITLE
refactor(deploy): single source of truth for the services list

### DIFF
--- a/src/deploy/commands/deploy.js
+++ b/src/deploy/commands/deploy.js
@@ -5,6 +5,7 @@
  */
 
 import { printStatus, printInfo, printWarning, printError } from '../remote-server.js';
+import { configKeyToSystemdName } from '../services.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -155,7 +156,7 @@ JOBS_EOF`);
   // Enable and start configured services
   const enabledServices = Object.entries(server.services || {})
     .filter(([_, enabled]) => enabled)
-    .map(([name]) => name === 'scheduler' ? 'today-scheduler' : name);
+    .map(([name]) => configKeyToSystemdName(name));
 
   if (enabledServices.length > 0) {
     printInfo(`Enabling configured services: ${enabledServices.join(', ')}`);
@@ -311,7 +312,7 @@ async function deployLocal(server) {
   // override translates these into `docker compose up -d <name>` calls.
   const enabledServices = Object.entries(server.services || {})
     .filter(([_, enabled]) => enabled)
-    .map(([name]) => name === 'scheduler' ? 'today-scheduler' : name);
+    .map(([name]) => configKeyToSystemdName(name));
 
   const startedServices = [];
   const failedServices = [];

--- a/src/deploy/commands/services.js
+++ b/src/deploy/commands/services.js
@@ -5,15 +5,9 @@
  */
 
 import { printStatus, printInfo, printWarning, printError } from '../remote-server.js';
+import { getSystemdUnitNames } from '../services.js';
 
-const SERVICES = [
-  'today-scheduler',
-  'vault-watcher',
-  'vault-web',
-  'inbox-api',
-  'resilio-sync',
-  'git-sync.timer'
-];
+const SERVICES = getSystemdUnitNames();
 
 export async function servicesCommand(server, args = []) {
   if (!server.validate()) {

--- a/src/deploy/config.js
+++ b/src/deploy/config.js
@@ -7,6 +7,7 @@
 
 import { execSync } from 'child_process';
 import { getFullConfig } from '../config.js';
+import { parseServicesConfig } from './services.js';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -125,15 +126,7 @@ export function getDeployments() {
       const ip = provider === 'local' ? 'localhost' : getDeploymentIp(provider, name);
 
       // Parse services config (default all to false for safety)
-      const servicesConfig = deploymentConfig.services || {};
-      const services = {
-        scheduler: servicesConfig.scheduler === true,
-        'vault-watcher': servicesConfig['vault-watcher'] === true,
-        'vault-web': servicesConfig['vault-web'] === true,
-        'inbox-api': servicesConfig['inbox-api'] === true,
-        'resilio-sync': servicesConfig['resilio-sync'] === true,
-        'git-sync.timer': servicesConfig['git-sync.timer'] === true
-      };
+      const services = parseServicesConfig(deploymentConfig.services);
 
       // Parse jobs config (use defaults if not specified)
       const jobsConfig = deploymentConfig.jobs || DEFAULT_JOBS;

--- a/src/deploy/providers/local.js
+++ b/src/deploy/providers/local.js
@@ -27,28 +27,14 @@
  */
 
 import { RemoteServer, printStatus, printInfo, printWarning } from '../remote-server.js';
+import { getSystemdToComposeMap } from '../services.js';
 import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-/**
- * Map a systemd service name to its docker-compose service name.
- *
- * The Today codebase uses systemd-style names everywhere (today-scheduler,
- * vault-watcher, etc.). When running locally via docker-compose, those map
- * to simpler compose service names.
- */
-const SYSTEMD_TO_COMPOSE = {
-  'today-scheduler': 'scheduler',
-  'scheduler': 'scheduler',
-  'vault-watcher': 'vault-watcher',
-  'vault-web': 'vault-web',
-  'inbox-api': 'inbox-api',
-  'today': 'today'
-};
+const SYSTEMD_TO_COMPOSE = getSystemdToComposeMap();
 
 function toComposeService(service) {
-  // Drop .timer / .service suffixes systemd uses.
   const bare = service.replace(/\.(service|timer)$/, '');
   return SYSTEMD_TO_COMPOSE[bare] || bare;
 }

--- a/src/deploy/services.js
+++ b/src/deploy/services.js
@@ -1,0 +1,135 @@
+/**
+ * Canonical list of Today services.
+ *
+ * Every piece of code that needs to know "what services exist" imports from
+ * here instead of maintaining its own hardcoded list. Adding a new service
+ * is a one-line change to the SERVICES array below; all call sites pick it
+ * up automatically.
+ *
+ * Previously this list was duplicated across six files with subtly different
+ * contents — see #214 for the full audit.
+ */
+
+/**
+ * @typedef {Object} ServiceDefinition
+ * @property {string} key - config.toml key under [deployments.*.services]
+ * @property {string} label - Human-readable name for the configure UI
+ * @property {string} description - Short description for the configure UI
+ * @property {string} systemdUnit - systemd unit name (e.g. 'today-scheduler.service')
+ * @property {string|null} composeService - docker-compose service name, or null if not compose-managed
+ */
+
+/** @type {ServiceDefinition[]} */
+export const SERVICES = [
+  {
+    key: 'scheduler',
+    label: 'Scheduler',
+    description: 'Run scheduled jobs',
+    systemdUnit: 'today-scheduler.service',
+    composeService: 'scheduler',
+  },
+  {
+    key: 'vault-watcher',
+    label: 'Vault Watcher',
+    description: 'Auto-commit vault changes as they happen',
+    systemdUnit: 'vault-watcher.service',
+    composeService: 'vault-watcher',
+  },
+  {
+    key: 'vault-web',
+    label: 'Vault Web',
+    description: 'Serve vault as static site',
+    systemdUnit: 'vault-web.service',
+    composeService: 'vault-web',
+  },
+  {
+    key: 'inbox-api',
+    label: 'Inbox API',
+    description: 'Receive uploads from mobile',
+    systemdUnit: 'inbox-api.service',
+    composeService: 'inbox-api',
+  },
+  {
+    key: 'resilio-sync',
+    label: 'Resilio Sync',
+    description: 'Peer-to-peer vault sync via Resilio daemon',
+    systemdUnit: 'resilio-sync.service',
+    composeService: null,
+  },
+  {
+    key: 'git-sync.timer',
+    label: 'Git Sync',
+    description: 'Sync committed git state via GitHub',
+    systemdUnit: 'git-sync.timer',
+    composeService: null,
+  },
+];
+
+/**
+ * Parse a services config block from config.toml into a normalized object.
+ * Used by deploy/config.js and tests.
+ *
+ * @param {Object} servicesConfig - Raw [deployments.*.services] from config.toml
+ * @returns {Object} { [key]: boolean } for every known service
+ */
+export function parseServicesConfig(servicesConfig) {
+  const config = servicesConfig || {};
+  return Object.fromEntries(
+    SERVICES.map(s => [s.key, config[s.key] === true])
+  );
+}
+
+/**
+ * Get the list of service keys for the configure UI.
+ * @returns {{ key: string, label: string, desc: string }[]}
+ */
+export function getServiceEntries() {
+  return SERVICES.map(s => ({
+    key: s.key,
+    label: s.label,
+    desc: s.description,
+  }));
+}
+
+/**
+ * Get all systemd unit names (for the services management command).
+ * @returns {string[]}
+ */
+export function getSystemdUnitNames() {
+  return SERVICES.map(s => s.systemdUnit);
+}
+
+/**
+ * Build a mapping from bare systemd names to compose service names.
+ * Used by the local provider to translate systemctl calls to compose.
+ *
+ * Maps both the full bare name ('today-scheduler') and the config key
+ * ('scheduler') to the compose service name, so either works as input.
+ *
+ * @returns {Object} { [systemdBareName|configKey]: composeServiceName }
+ */
+export function getSystemdToComposeMap() {
+  const map = {};
+  for (const s of SERVICES) {
+    if (s.composeService) {
+      const bare = s.systemdUnit.replace(/\.(service|timer)$/, '');
+      map[bare] = s.composeService;
+      map[s.key] = s.composeService;
+      map[s.composeService] = s.composeService;
+    }
+  }
+  return map;
+}
+
+/**
+ * Convert a config.toml service key to its systemd bare name.
+ * e.g. 'scheduler' → 'today-scheduler', 'vault-web' → 'vault-web'
+ *
+ * @param {string} key - Service key from config.toml
+ * @returns {string} Bare systemd name (without .service/.timer suffix)
+ */
+export function configKeyToSystemdName(key) {
+  const service = SERVICES.find(s => s.key === key);
+  if (!service) return key;
+  return service.systemdUnit.replace(/\.(service|timer)$/, '');
+}

--- a/src/deployments-configure-ui.js
+++ b/src/deployments-configure-ui.js
@@ -8,6 +8,7 @@
 import React, { useState } from 'react';
 import { render, Box, Text, useInput, useApp } from 'ink';
 import { TextInput, Select } from '@inkjs/ui';
+import { getServiceEntries } from './deploy/services.js';
 import htm from 'htm';
 import fs from 'fs';
 import path from 'path';
@@ -266,7 +267,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
 
     // Services mode
     if (mode === 'services') {
-      const serviceKeys = ['scheduler', 'vault-watcher', 'inbox-api', 'vault-web', '__back__'];
+      const serviceKeys = [...getServiceEntries().map(s => s.key), '__back__'];
       if (key.escape || input === 'q') {
         setMode('edit');
         setServiceIndex(0);
@@ -665,12 +666,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
   if (mode === 'edit' && selected) {
     // Get current services config
     const services = selected.services || {};
-    const servicesList = [
-      { key: 'scheduler', label: 'Scheduler', desc: 'Run scheduled jobs' },
-      { key: 'vault-watcher', label: 'Vault Watcher', desc: 'Auto-commit vault changes as they happen' },
-      { key: 'inbox-api', label: 'Inbox API', desc: 'Receive uploads from mobile' },
-      { key: 'vault-web', label: 'Vault Web', desc: 'Serve vault as static site' },
-    ];
+    const servicesList = getServiceEntries();
 
     // Get current jobs
     const jobs = selected.jobs || {};
@@ -764,12 +760,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
 
   if (mode === 'services' && selected) {
     const services = selected.services || {};
-    const servicesList = [
-      { key: 'scheduler', label: 'Scheduler', desc: 'Run scheduled jobs' },
-      { key: 'vault-watcher', label: 'Vault Watcher', desc: 'Auto-commit vault changes as they happen' },
-      { key: 'inbox-api', label: 'Inbox API', desc: 'Receive uploads from mobile' },
-      { key: 'vault-web', label: 'Vault Web', desc: 'Serve vault as static site' },
-    ];
+    const servicesList = getServiceEntries();
 
     const serviceRows = servicesList.map((s, i) => {
       const isSelected = i === serviceIndex;

--- a/test/deploy-config.test.js
+++ b/test/deploy-config.test.js
@@ -3,6 +3,7 @@
  */
 
 import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+import { parseServicesConfig, SERVICES, getServiceEntries, getSystemdUnitNames, getSystemdToComposeMap, configKeyToSystemdName } from '../src/deploy/services.js';
 
 // We'll test the config parsing logic directly by examining the output
 // Since the actual module has dependencies on external services (dotenvx),
@@ -32,17 +33,8 @@ describe('deploy/config', () => {
   });
 
   describe('services config parsing', () => {
-    // Test the services parsing logic
-    function parseServices(servicesConfig) {
-      const config = servicesConfig || {};
-      return {
-        scheduler: config.scheduler === true,
-        'vault-web': config['vault-web'] === true,
-        'inbox-api': config['inbox-api'] === true,
-        'resilio-sync': config['resilio-sync'] === true,
-        'git-sync.timer': config['git-sync.timer'] === true
-      };
-    }
+    // Use the real parseServicesConfig from the shared module
+    const parseServices = parseServicesConfig;
 
     test('parses enabled services', () => {
       const services = parseServices({
@@ -73,6 +65,64 @@ describe('deploy/config', () => {
       });
       expect(services.scheduler).toBe(false);
       expect(services['vault-web']).toBe(false);
+    });
+
+    test('includes vault-watcher in parsed output', () => {
+      const services = parseServices({ 'vault-watcher': true });
+      expect(services['vault-watcher']).toBe(true);
+    });
+  });
+
+  describe('services module (single source of truth)', () => {
+    test('SERVICES array contains all expected services', () => {
+      const keys = SERVICES.map(s => s.key);
+      expect(keys).toContain('scheduler');
+      expect(keys).toContain('vault-watcher');
+      expect(keys).toContain('vault-web');
+      expect(keys).toContain('inbox-api');
+      expect(keys).toContain('resilio-sync');
+      expect(keys).toContain('git-sync.timer');
+    });
+
+    test('every service has required fields', () => {
+      for (const s of SERVICES) {
+        expect(s.key).toBeTruthy();
+        expect(s.label).toBeTruthy();
+        expect(s.description).toBeTruthy();
+        expect(s.systemdUnit).toBeTruthy();
+      }
+    });
+
+    test('getServiceEntries returns entries with key/label/desc', () => {
+      const entries = getServiceEntries();
+      expect(entries.length).toBe(SERVICES.length);
+      for (const e of entries) {
+        expect(e).toHaveProperty('key');
+        expect(e).toHaveProperty('label');
+        expect(e).toHaveProperty('desc');
+      }
+    });
+
+    test('getSystemdUnitNames returns all unit names', () => {
+      const names = getSystemdUnitNames();
+      expect(names).toContain('today-scheduler.service');
+      expect(names).toContain('vault-watcher.service');
+      expect(names).toContain('git-sync.timer');
+    });
+
+    test('getSystemdToComposeMap maps both bare names and config keys', () => {
+      const map = getSystemdToComposeMap();
+      expect(map['today-scheduler']).toBe('scheduler');
+      expect(map['scheduler']).toBe('scheduler');
+      expect(map['vault-watcher']).toBe('vault-watcher');
+      expect(map['vault-web']).toBe('vault-web');
+    });
+
+    test('configKeyToSystemdName handles scheduler special case', () => {
+      expect(configKeyToSystemdName('scheduler')).toBe('today-scheduler');
+      expect(configKeyToSystemdName('vault-web')).toBe('vault-web');
+      expect(configKeyToSystemdName('git-sync.timer')).toBe('git-sync');
+      expect(configKeyToSystemdName('unknown')).toBe('unknown');
     });
   });
 


### PR DESCRIPTION
Closes #214.

## Problem

The service list was duplicated across six files, each subtly different. Adding vault-watcher (#213) and git-sync.timer (#197) both required editing multiple files and both missed at least one.

## Solution

New \`src/deploy/services.js\` — one canonical array of service definitions. Every call site imports helpers from it:

| Call site | Was | Now |
|---|---|---|
| \`deploy/config.js\` | 6-line object literal | \`parseServicesConfig()\` |
| \`deploy/commands/services.js\` | hardcoded \`SERVICES\` array | \`getSystemdUnitNames()\` |
| \`deploy/providers/local.js\` | hardcoded \`SYSTEMD_TO_COMPOSE\` | \`getSystemdToComposeMap()\` |
| \`deploy/commands/deploy.js\` | \`name === 'scheduler' ? 'today-scheduler' : name\` | \`configKeyToSystemdName()\` |
| \`deployments-configure-ui.js\` | 3 separate hardcoded \`servicesList\` arrays | \`getServiceEntries()\` |

Adding a new service (e.g. \`unison-sync\` for #217) is now a one-line addition to the \`SERVICES\` array.

## Tests

7 new tests covering the module's helpers. Total: 19 passing (was 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)