### PR TITLE
fix(unison-sync): use real config.js + skip non-compose services

### DIFF
--- a/bin/unison-sync
+++ b/bin/unison-sync
@@ -30,10 +30,11 @@
  *   2  unison failed
  */
 
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getFullConfig } from '../src/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,46 +43,8 @@ const PROJECT_ROOT = dirname(__dirname);
 // ── Config ──────────────────────────────────────────────────────────
 
 function readConfig() {
-  // Minimal config reader — avoids importing the full config.js which
-  // pulls in many dependencies. We just need the TOML file.
   try {
-    // Check for config-path pointer (used by deployments)
-    const configPathFile = join(PROJECT_ROOT, '.data', 'config-path');
-    let configPath;
-    if (existsSync(configPathFile)) {
-      const relative = readFileSync(configPathFile, 'utf8').trim();
-      configPath = join(PROJECT_ROOT, relative);
-    } else {
-      configPath = join(PROJECT_ROOT, 'config.toml');
-    }
-
-    if (!existsSync(configPath)) {
-      // Try vault/today.toml as fallback
-      const vaultConfig = join(PROJECT_ROOT, 'vault', 'today.toml');
-      if (existsSync(vaultConfig)) {
-        configPath = vaultConfig;
-      } else {
-        return null;
-      }
-    }
-
-    // Dynamic import of @iarna/toml to parse
-    const tomlStr = readFileSync(configPath, 'utf8');
-    // Simple inline TOML parser for the fields we need — avoids the
-    // dependency on @iarna/toml which may not be installed in the
-    // minimal unison-sync image. We shell out to node with the full
-    // app's node_modules if available, otherwise fall back to a
-    // basic regex parse.
-    try {
-      const result = execSync(
-        `node -e "const t=require('@iarna/toml');const fs=require('fs');console.log(JSON.stringify(t.parse(fs.readFileSync('${configPath}','utf8'))))"`,
-        { cwd: PROJECT_ROOT, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-      );
-      return JSON.parse(result);
-    } catch {
-      console.error('Could not parse config.toml — is @iarna/toml installed?');
-      return null;
-    }
+    return getFullConfig();
   } catch (err) {
     console.error(`Config error: ${err.message}`);
     return null;

--- a/src/deploy/providers/local.js
+++ b/src/deploy/providers/local.js
@@ -34,9 +34,14 @@ import path from 'path';
 
 const SYSTEMD_TO_COMPOSE = getSystemdToComposeMap();
 
+/**
+ * Map a systemd service name to its compose equivalent, or null if the
+ * service has no compose representation (e.g. git-sync.timer runs as a
+ * scheduler cron job, not a compose service).
+ */
 function toComposeService(service) {
   const bare = service.replace(/\.(service|timer)$/, '');
-  return SYSTEMD_TO_COMPOSE[bare] || bare;
+  return SYSTEMD_TO_COMPOSE[bare] || null;
 }
 
 export class LocalProvider extends RemoteServer {
@@ -152,6 +157,14 @@ export class LocalProvider extends RemoteServer {
   systemctl(action, service, options = {}) {
     const svc = toComposeService(service);
     const { check = false } = options;
+
+    // Services without a compose equivalent (e.g. git-sync.timer, which
+    // runs as a scheduler cron job on local deployments) are silently
+    // skipped — there's no compose service to start/stop.
+    if (!svc) {
+      return { returncode: 0 };
+    }
+
     let cmd;
     switch (action) {
       case 'start':


### PR DESCRIPTION
Two fixes from the first Mac test of unison-sync:

1. **bin/unison-sync** had a custom minimal config reader that couldn't find \`vault/today.toml\` (the user's config, referenced via \`.data/config-path\`). Replaced with \`getFullConfig()\` from \`src/config.js\` — the bind mount provides everything at runtime, so a minimal reader was unnecessary.

2. **LocalProvider.systemctl** tried \`docker compose up -d git-sync\` for services without compose equivalents. \`toComposeService()\` now returns null for unknown services, and systemctl no-ops instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)