### PR TITLE
fix: add unison-sync to vault mount override

### DIFF
--- a/.devcontainer/generate-compose-override.sh
+++ b/.devcontainer/generate-compose-override.sh
@@ -107,6 +107,9 @@ services:
   inbox-api:
     volumes:
       - "$VAULT_SRC:/app/vault:cached"
+  unison-sync:
+    volumes:
+      - "$VAULT_SRC:/app/vault:cached"
 EOF
     echo "Root override file generated: $ROOT_OVERRIDE_FILE (vault -> $VAULT_SRC)"
 else


### PR DESCRIPTION
The root \`docker-compose.override.yml\` (generated by \`generate-compose-override.sh\`) listed 5 services for the iCloud vault bind mount but didn't include \`unison-sync\` (which was added after the script was written). 

Result: the unison-sync container read config from the stale \`./vault\` on the host project instead of the real iCloud vault, got a minimal config with only \`timezone\`, and printed "Deployment 'macbook' not found."

Adds \`unison-sync\` to the generated override. After merge: rebuild the devcontainer (so the script runs), then \`docker compose down && bin/deploy macbook\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)