### PR TITLE
fix: run unison-sync via dotenvx so encrypted env vars are available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       context: .
       dockerfile: deploy/docker/Dockerfile.unison-sync
     container_name: today-unison-sync
+    command: ["npx", "dotenvx", "run", "--", "node", "bin/unison-sync"]
     environment:
       - DOTENV_PRIVATE_KEY=${DOTENV_PRIVATE_KEY:-}
     volumes:


### PR DESCRIPTION
The droplet's IP is encrypted in .env. All other compose services run via \`npx dotenvx run --\` to decrypt env vars, but unison-sync ran \`bin/unison-sync\` directly (no dotenvx), so \`DEPLOY_DIGITALOCEAN_DROPLET_IP\` wasn't available. One-line fix: add the same dotenvx wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)