### PR TITLE
fix(unison-sync): decrypt deploy key from .env instead of mounting host SSH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,12 +124,16 @@ services:
       context: .
       dockerfile: deploy/docker/Dockerfile.unison-sync
     container_name: today-unison-sync
-    command: ["npx", "dotenvx", "run", "--", "node", "bin/unison-sync"]
+    # Run setup-ssh-keys.sh first to decrypt the deploy key from .env,
+    # then start unison-sync. Both run under dotenvx so encrypted env
+    # vars (DO_DEPLOY_KEY_PRIVATE, DO_DROPLET_IP, etc.) are available.
+    # No host SSH mount needed — the key comes from .env, same as the
+    # devcontainer's postCreateCommand.
+    command: ["npx", "dotenvx", "run", "--overload", "--", "sh", "-c", ".devcontainer/setup-ssh-keys.sh && node bin/unison-sync"]
     environment:
       - DOTENV_PRIVATE_KEY=${DOTENV_PRIVATE_KEY:-}
     volumes:
       - ${HOST_PROJECT_PATH:-.}:/app
-      - ${HOST_HOME:-~}/.ssh:/root/.ssh:ro
     restart: unless-stopped
 
   ollama:


### PR DESCRIPTION
The unison-sync container was mounting the Mac host's \`~/.ssh\` read-only, but the deploy key (\`do_deploy_key\`) only exists inside the devcontainer — it's decrypted from \`.env\` by \`setup-ssh-keys.sh\` during the devcontainer's \`postCreateCommand\`. The host's \`~/.ssh\` only has the user's personal key, which isn't authorized on the droplet.

**Fix**: Remove the host SSH mount. Instead, run \`setup-ssh-keys.sh\` at container startup (same script the devcontainer uses) under dotenvx. This decrypts \`DO_DEPLOY_KEY_PRIVATE\` from \`.env\` and writes it to \`~/.ssh/do_deploy_key\` inside the container. Works for any Today user — the deploy key is part of the encrypted \`.env\`, not a host-specific file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)