### PR TITLE
fix(unison-sync): stable hostname so archives persist across restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,10 @@ services:
     command: ["npx", "dotenvx", "run", "--overload", "--", "sh", "-c", ".devcontainer/setup-ssh-keys.sh && node bin/unison-sync"]
     environment:
       - DOTENV_PRIVATE_KEY=${DOTENV_PRIVATE_KEY:-}
+      # Stable hostname so Unison's archive persists across container recreations.
+      # Without this, each new container gets a random hostname and Unison treats
+      # every restart as a first sync.
+      - UNISONLOCALHOSTNAME=today-unison
     volumes:
       - ${HOST_PROJECT_PATH:-.}:/app
     restart: unless-stopped


### PR DESCRIPTION
Each container recreation gets a random hostname (e.g. \`df0171c0a9bc\` → \`01a7d2d4e76e\`). Unison keys its archive by hostname, so every \`bin/deploy\` restart triggered "No archive files found" and a full re-scan. Sets \`UNISONLOCALHOSTNAME=today-unison\` so the archive persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)