### PR TITLE
perf: build base image once and shrink Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 .git
+.git.nosync
 .gitignore
 README.md
 Dockerfile
@@ -11,3 +12,13 @@ Dockerfile
 .env.keys
 .DS_Store
 *.log
+
+# Large directories not needed in the build image (bind-mounted at runtime)
+vault/
+.devcontainer/
+deploy/
+test/
+docs/
+.worktrees/
+.claude/
+.obsidian/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   # which bin/deploy writes from [deployments.local.<name>.jobs.*].
   scheduler:
     build: .
+    image: today-app:latest
     container_name: today-scheduler
     command: ["npx", "dotenvx", "run", "--", "node", "src/scheduler.js"]
     environment:
@@ -69,7 +70,7 @@ services:
   # decrypted by dotenvx at runtime) so compose can't know it at parse time.
   # VS Code auto-forwards the port when it detects the server listening.
   vault-web:
-    build: .
+    image: today-app:latest
     container_name: today-vault-web
     command: ["npx", "dotenvx", "run", "--", "node", "src/web-server.js"]
     environment:
@@ -84,7 +85,7 @@ services:
 
   # Runs node src/vault-watcher.js — real-time file change watcher.
   vault-watcher:
-    build: .
+    image: today-app:latest
     container_name: today-vault-watcher
     command: ["npx", "dotenvx", "run", "--", "node", "src/vault-watcher.js"]
     environment:
@@ -99,7 +100,7 @@ services:
 
   # Runs node src/inbox-api.js — HTTPS upload endpoint for mobile apps.
   inbox-api:
-    build: .
+    image: today-app:latest
     container_name: today-inbox-api
     command: ["node", "src/inbox-api.js"]
     environment:


### PR DESCRIPTION
\`bin/deploy macbook\` was slow (~60s) because it built the same Dockerfile four times (one per service) and sent ~1.8 MB of context each time.

1. **Deduplicate**: scheduler builds \`today-app:latest\`, other services just reference it via \`image:\`
2. **Shrink context**: \`.dockerignore\` now excludes vault/, .devcontainer/, deploy/, test/, docs/

Expected: ~10s total instead of ~60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)