### PR TITLE
fix(unison-sync): per-deployment hostname so multiple Macs don't conflict

### DIFF
--- a/bin/unison-sync
+++ b/bin/unison-sync
@@ -165,10 +165,16 @@ if (syncPaths.length > 0) {
 console.log(`  Excludes: ${allExcludes.length} patterns`);
 console.log('');
 
-// Run unison
+// Run unison. UNISONLOCALHOSTNAME must be stable per-deployment so the
+// archive persists across container recreations AND is distinct between
+// different machines (e.g. macbook vs mini) syncing to the same target.
 const child = spawn('unison', args, {
   stdio: 'inherit',
-  env: { ...process.env, UNISON: join(PROJECT_ROOT, '.data', 'unison') }
+  env: {
+    ...process.env,
+    UNISON: join(PROJECT_ROOT, '.data', 'unison'),
+    UNISONLOCALHOSTNAME: `today-${deploymentName}`,
+  }
 });
 
 child.on('error', (err) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,10 +133,6 @@ services:
     command: ["npx", "dotenvx", "run", "--overload", "--", "sh", "-c", ".devcontainer/setup-ssh-keys.sh && node bin/unison-sync"]
     environment:
       - DOTENV_PRIVATE_KEY=${DOTENV_PRIVATE_KEY:-}
-      # Stable hostname so Unison's archive persists across container recreations.
-      # Without this, each new container gets a random hostname and Unison treats
-      # every restart as a first sync.
-      - UNISONLOCALHOSTNAME=today-unison
     volumes:
       - ${HOST_PROJECT_PATH:-.}:/app
     restart: unless-stopped


### PR DESCRIPTION
\`UNISONLOCALHOSTNAME\` was hardcoded to \`today-unison\`, so all Macs appeared as the same host. Mac mini connecting after MacBook hit "inconsistent state" because the droplet had archives from MacBook under the same hostname.

Moved to \`bin/unison-sync\` where it's set to \`today-\${deploymentName}\` (e.g. \`today-macbook\`, \`today-mini\`). Each machine gets its own archive pair.

Also cleared stale archives on the droplet so both Macs start fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)