### PR TITLE
fix(unison-sync): ignore permission differences between macOS and Linux

### DIFF
--- a/bin/unison-sync
+++ b/bin/unison-sync
@@ -134,6 +134,8 @@ const args = [
   '-batch',          // non-interactive
   '-auto',           // accept non-conflicting changes automatically
   '-prefer', 'newer', // for conflicts, prefer the newer version (configurable later)
+  '-perms', '0',     // ignore permission differences (macOS vs Linux)
+  '-dontchmod',      // don't try to set permissions on the remote
   '-sshargs', `-p ${sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${resolveSSHKey(targetDeployment)}`,
 ];
 


### PR DESCRIPTION
Unison was skipping 688 files with "properties changed on both sides" because macOS and Linux report different file permissions. Adds \`-perms 0\` and \`-dontchmod\` — file content is what matters for vault sync, not filesystem permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)