### PR TITLE
feat: add jitter to scheduler jobs and vault watcher to reduce iCloud conflicts

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -6,7 +6,7 @@ import { promisify } from 'util';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { getTimezone } from './config.js';
+import { getTimezone, getConfig } from './config.js';
 
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
@@ -149,6 +149,11 @@ function loadJobs() {
   return jobs;
 }
 
+// Max jitter in milliseconds added before each job to avoid thundering herd
+// when multiple machines run the same schedule. 15s default keeps jobs within
+// their cron window while spreading them out enough to avoid iCloud conflicts.
+const JITTER_MS = (getConfig('scheduler_jitter_seconds') || 15) * 1000;
+
 async function runCommand(command, description) {
   // Check if sync is disabled due to missing data
   if (fs.existsSync(path.join(PROJECT_ROOT, 'SYNC_DISABLED')) && command.includes('sync')) {
@@ -156,6 +161,12 @@ async function runCommand(command, description) {
     console.log(`\n[${timestamp}] SKIPPED: ${description}`);
     console.log(`⚠️  Sync is disabled to prevent data loss. Check GitHub repository.`);
     return;
+  }
+
+  // Random jitter to avoid multiple machines firing the same job simultaneously
+  if (JITTER_MS > 0) {
+    const delay = Math.floor(Math.random() * JITTER_MS);
+    await new Promise(resolve => setTimeout(resolve, delay));
   }
 
   const timestamp = new Date().toISOString();

--- a/src/vault-watcher.js
+++ b/src/vault-watcher.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import {
   getTimezone, getAbsoluteVaultPath, getConfig, getVaultPath,
-  getConfigPath, clearConfigCache
+  getConfigPath, clearConfigCache, getDeploymentName
 } from './config.js';
 import { getDatabase } from './database-service.js';
 import { ensureHealthyDatabase } from './db-health.js';
@@ -249,10 +249,17 @@ async function runSync() {
   }
 }
 
+// Per-deployment jitter added to the debounce so multiple machines don't
+// process the same file change at the exact same instant. Uses a simple
+// hash of the deployment name to produce a consistent offset (0-2000ms).
+const deployName = getDeploymentName() || '';
+const watcherJitter = [...deployName].reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0);
+const WATCHER_JITTER_MS = Math.abs(watcherJitter % 2000);
+
 function scheduleSync(filePath) {
   pendingChanges.add(filePath);
   clearTimeout(debounceTimer);
-  debounceTimer = setTimeout(runSync, watcherConfig.debounce);
+  debounceTimer = setTimeout(runSync, watcherConfig.debounce + WATCHER_JITTER_MS);
 }
 
 // Build chokidar ignored patterns from config


### PR DESCRIPTION
When multiple Macs run the same cron schedule, they fire simultaneously and both modify files, causing iCloud conflict copies.

**Scheduler**: random delay (0 to \`scheduler_jitter_seconds\`, default 15s) before each job. Configurable in config.toml.

**Vault watcher**: consistent per-deployment offset (0-2000ms, hash of deployment name) added to the debounce timer. Macbook and mini naturally process changes at slightly different times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)