### PR TITLE
feat: support personal-setup.sh for per-user devcontainer tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 			]
 		}
 	},
-	"postCreateCommand": "npm install && chmod +x bin/* && npx dotenvx run --overload -- .devcontainer/setup-ssh-keys.sh",
+	"postCreateCommand": "npm install && chmod +x bin/* && npx dotenvx run --overload -- .devcontainer/setup-ssh-keys.sh && [ -f .devcontainer/personal-setup.sh ] && bash .devcontainer/personal-setup.sh || true",
 	"postStartCommand": "bash .devcontainer/devcontainer-startup",
 	"containerEnv": {
 		"DEVCONTAINER_HOST_MACHINE": "${localEnv:HOSTNAME}${localEnv:COMPUTERNAME}",

--- a/.devcontainer/personal-setup.sh.example
+++ b/.devcontainer/personal-setup.sh.example
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Personal devcontainer setup — install your preferred tools here.
+#
+# Copy this file to personal-setup.sh (which is gitignored) and customize.
+# It runs automatically after each container create/rebuild via postCreateCommand.
+# The devcontainer runs as the 'node' user, so use sudo for system changes.
+#
+# Example:
+
+# sudo apt-get update && sudo apt-get install -y fish tmux
+# sudo chsh -s /usr/bin/fish node

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ __pycache__/
 # DevContainer Local Config
 # =============================================================================
 .devcontainer/mounts.local
+.devcontainer/personal-setup.sh
 .devcontainer/docker-compose.override.yml
 # Root-level docker-compose override is auto-generated from
 # .devcontainer/mounts.local by generate-compose-override.sh and points


### PR DESCRIPTION
Tools installed manually in a running container are lost on rebuild. Adds a \`.devcontainer/personal-setup.sh\` convention (gitignored, like \`mounts.local\`) that runs automatically during \`postCreateCommand\`.

Users create their own script once — it lives on the host filesystem, survives rebuilds, and doesn't affect other users.

Example:
\`\`\`bash
apt-get update && apt-get install -y fish tmux
chsh -s /usr/bin/fish
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)