### PR TITLE
feat: support personal-startup.sh for per-user services on container start

### DIFF
--- a/.devcontainer/devcontainer-startup
+++ b/.devcontainer/devcontainer-startup
@@ -20,5 +20,14 @@ else
 fi
 
 echo ""
+
+# Run personal startup script if present (for per-user long-running
+# services like code tunnel). Separate from personal-setup.sh which
+# runs only on create; this runs on every start.
+if [ -f .devcontainer/personal-startup.sh ]; then
+    echo "Running personal startup..."
+    bash .devcontainer/personal-startup.sh
+fi
+
 echo "DevContainer startup complete!"
 echo "Run 'bin/today' to start an interactive session."

--- a/.devcontainer/personal-startup.sh.example
+++ b/.devcontainer/personal-startup.sh.example
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Personal devcontainer startup — runs on every container start.
+#
+# Copy this file to personal-startup.sh (which is gitignored) and customize.
+# Use this for long-running personal services. For one-time tool installation,
+# use personal-setup.sh instead (runs only on create/rebuild).
+#
+# Example — VS Code remote tunnel with persistent auth and auto-restart:
+#
+# nohup bash -c '
+#   while true; do
+#     code tunnel --accept-server-license-terms --cli-data-dir /app/.data/vscode-cli
+#     echo "$(date): Code tunnel exited, restarting in 5s..." >> /tmp/code-tunnel.log
+#     sleep 5
+#   done
+# ' > /tmp/code-tunnel.log 2>&1 &
+# echo "  Code tunnel started (log: /tmp/code-tunnel.log)"
+#
+# --cli-data-dir on the bind-mounted /app/.data/ persists auth across rebuilds.
+# The restart loop recovers from crashes when you're away.

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ __pycache__/
 # =============================================================================
 .devcontainer/mounts.local
 .devcontainer/personal-setup.sh
+.devcontainer/personal-startup.sh
 .devcontainer/docker-compose.override.yml
 # Root-level docker-compose override is auto-generated from
 # .devcontainer/mounts.local by generate-compose-override.sh and points


### PR DESCRIPTION
Companion to \`personal-setup.sh\` (#235, runs on create only). \`personal-startup.sh\` runs on **every container start** via \`postStartCommand\`, for long-running personal services like \`code tunnel\`.

Same gitignored/per-user convention as \`mounts.local\` and \`personal-setup.sh\`.

Example for VS Code tunnel:
\`\`\`bash
nohup code tunnel --accept-server-license-terms > /tmp/code-tunnel.log 2>&1 &
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)