### PR TITLE
fix(plans): bound markdown-plans AI volume and keep long syncs locked

### DIFF
--- a/plugins/markdown-plans/plugin.toml
+++ b/plugins/markdown-plans/plugin.toml
@@ -33,3 +33,4 @@ read = "./read.js"
 plans_directory = { type = "string", default = "vault/plans", description = "Directory containing plan files" }
 templates_directory = { type = "string", default = "vault/plans/templates", description = "Directory containing plan templates" }
 link_daily_notes = { type = "boolean", default = true, description = "Add link to today's plan at top of Obsidian daily note" }
+max_ai_calls_per_run = { type = "number", default = 5, description = "Cap on AI generation calls per invocation. Backlog drains across multiple runs instead of blocking on one giant queue." }

--- a/plugins/markdown-plans/read.js
+++ b/plugins/markdown-plans/read.js
@@ -38,9 +38,12 @@ const contextOnly = process.env.CONTEXT_ONLY === 'true' || isWatcherRun;
 // Per-run AI call budget. Bounds backlog-drain runs so dozens of missing
 // summaries get processed across multiple invocations instead of one giant queue
 // that blocks the model for hours on local CPU Ollama.
-const maxAiCallsPerRun = Number(
-  process.env.MARKDOWN_PLANS_MAX_AI_CALLS ?? config.max_ai_calls_per_run ?? 5
+const parsedMaxAiCallsPerRun = Number(
+  process.env.MARKDOWN_PLANS_MAX_AI_CALLS ?? config.max_ai_calls_per_run
 );
+const maxAiCallsPerRun = Number.isFinite(parsedMaxAiCallsPerRun) && parsedMaxAiCallsPerRun >= 0
+  ? Math.floor(parsedMaxAiCallsPerRun)
+  : 5;
 let aiCallsThisRun = 0;
 let aiCallsDeferred = 0;
 function aiBudgetExhausted() {
@@ -893,7 +896,7 @@ function migrateAllNavigationToWidget() {
  * Generate AI summary for a specific date
  * Uses bin/today dry-run --date to get the full context for that date
  */
-async function generateDailySummary(dateStr, planFilePath) {
+async function generateDailySummary(dateStr, planFilePath, onAiCall) {
   // Check if AI is available
   if (!(await isAIAvailable())) {
     return null;
@@ -949,6 +952,7 @@ Write ONLY the 2-3 sentence summary for ${dateStr}, nothing else:`;
 
   // Call AI provider
   try {
+    if (onAiCall) onAiCall();
     const response = await createCompletion({
       messages: [{ role: 'user', content: prompt }],
       maxTokens: 300,
@@ -1409,7 +1413,7 @@ function needsPriorities(filePath) {
 /**
  * Generate AI suggestions for tomorrow's plan
  */
-async function generateTomorrowSuggestions(tomorrowStr, planFilePath) {
+async function generateTomorrowSuggestions(tomorrowStr, planFilePath, onAiCall) {
   // Check if AI is available
   if (!(await isAIAvailable())) {
     return null;
@@ -1480,6 +1484,7 @@ Keep it concise and actionable. Tasks should be specific and achievable.`;
 
   // Call AI provider
   try {
+    if (onAiCall) onAiCall();
     const response = await createCompletion({
       messages: [{ role: 'user', content: prompt }],
       maxTokens: 500,
@@ -3310,7 +3315,7 @@ function getPlanThemeGoalsStatus(planPath, planType) {
 /**
  * Generate suggested theme and goals for a plan using AI
  */
-async function suggestThemeAndGoals(planPath, planType, startDate, endDate) {
+async function suggestThemeAndGoals(planPath, planType, startDate, endDate, onAiCall) {
   // Check if AI is available
   if (!(await isAIAvailable())) {
     return null;
@@ -3495,6 +3500,7 @@ ${goalsFieldName.toUpperCase()}:
 Make the theme distinctive to THIS period. Make ${goalsFieldName} specific and achievable.`;
 
   try {
+    if (onAiCall) onAiCall();
     const response = await createCompletion({
       messages: [{ role: 'user', content: prompt }],
       maxTokens: 400,
@@ -3655,8 +3661,7 @@ async function suggestMissingThemesAndGoals(today) {
     }
 
     // Generate suggestions
-    recordAiCall();
-    const suggestion = await suggestThemeAndGoals(filePath, planType, dates.startDate, dates.endDate);
+    const suggestion = await suggestThemeAndGoals(filePath, planType, dates.startDate, dates.endDate, recordAiCall);
 
     if (suggestion && suggestion.theme && suggestion.goals && suggestion.goals.length > 0) {
       // Only update if we have good suggestions
@@ -3710,7 +3715,7 @@ function getPlanSummaryStatus(planPath, planType) {
 /**
  * Generate a summary for a past plan period using AI
  */
-async function generatePlanSummary(planPath, planType, startDate, endDate) {
+async function generatePlanSummary(planPath, planType, startDate, endDate, onAiCall) {
   // Check if AI is available
   if (!(await isAIAvailable())) {
     return null;
@@ -3856,6 +3861,7 @@ ${context}
 Write ONLY the summary, ${sentenceCount} sentences, nothing else. Be specific and personal, not generic.`;
 
   try {
+    if (onAiCall) onAiCall();
     const response = await createCompletion({
       messages: [{ role: 'user', content: prompt }],
       maxTokens: 400,
@@ -3987,8 +3993,7 @@ async function suggestMissingSummaries(today) {
     }
 
     // Generate summary
-    recordAiCall();
-    const summary = await generatePlanSummary(filePath, planType, dates.startDate, dates.endDate);
+    const summary = await generatePlanSummary(filePath, planType, dates.startDate, dates.endDate, recordAiCall);
 
     if (summary) {
       const updated = updatePlanWithSummary(filePath, planType, summary);
@@ -4320,8 +4325,7 @@ async function main() {
     const daysNeedingSummaries = getPastDaysNeedingSummaries(today, 7);
     for (const dayInfo of daysNeedingSummaries) {
       if (aiBudgetExhausted()) break;
-      recordAiCall();
-      const summary = await generateDailySummary(dayInfo.dateStr, dayInfo.path);
+      const summary = await generateDailySummary(dayInfo.dateStr, dayInfo.path, recordAiCall);
       if (summary) {
         addSummaryToFile(dayInfo.path, summary);
         metadata.summaries_generated.push({
@@ -4333,8 +4337,7 @@ async function main() {
 
     // Generate suggestions for tomorrow's plan if needed
     if (needsPriorities(tomorrowPaths.day.path) && !aiBudgetExhausted()) {
-      recordAiCall();
-      const suggestions = await generateTomorrowSuggestions(tomorrowStr, tomorrowPaths.day.path);
+      const suggestions = await generateTomorrowSuggestions(tomorrowStr, tomorrowPaths.day.path, recordAiCall);
       if (suggestions && updateTomorrowPlan(tomorrowPaths.day.path, suggestions)) {
         metadata.tomorrow_updated = true;
       }

--- a/plugins/markdown-plans/read.js
+++ b/plugins/markdown-plans/read.js
@@ -27,7 +27,32 @@ import { writeFileAtomic, writeFileAtomicCAS } from '../../src/fs-atomic.js';
 
 const config = JSON.parse(process.env.PLUGIN_CONFIG || '{}');
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
-const contextOnly = process.env.CONTEXT_ONLY === 'true'; // Skip expensive AI operations
+
+// FILE_FILTER is set by vault-watcher when a small set of files changed.
+// Watcher-triggered runs skip the AI backlog drain; that work belongs on
+// manual `bin/plugins sync markdown-plans` or a scheduled run, not on every edit.
+const fileFilter = process.env.FILE_FILTER || '';
+const isWatcherRun = fileFilter.length > 0;
+const contextOnly = process.env.CONTEXT_ONLY === 'true' || isWatcherRun;
+
+// Per-run AI call budget. Bounds backlog-drain runs so dozens of missing
+// summaries get processed across multiple invocations instead of one giant queue
+// that blocks the model for hours on local CPU Ollama.
+const maxAiCallsPerRun = Number(
+  process.env.MARKDOWN_PLANS_MAX_AI_CALLS ?? config.max_ai_calls_per_run ?? 5
+);
+let aiCallsThisRun = 0;
+let aiCallsDeferred = 0;
+function aiBudgetExhausted() {
+  if (aiCallsThisRun >= maxAiCallsPerRun) {
+    aiCallsDeferred++;
+    return true;
+  }
+  return false;
+}
+function recordAiCall() {
+  aiCallsThisRun++;
+}
 
 const plansDirectory = config.plans_directory || (process.env.VAULT_PATH ? `${process.env.VAULT_PATH}/plans` : 'vault/plans');
 const templatesDirectory = config.templates_directory || (process.env.VAULT_PATH ? `${process.env.VAULT_PATH}/plans/templates` : 'vault/plans/templates');
@@ -3624,7 +3649,13 @@ async function suggestMissingThemesAndGoals(today) {
     // Skip if both are already filled
     if (!status.themeEmpty && !status.goalsEmpty) continue;
 
+    if (aiBudgetExhausted()) {
+      results.skipped.push({ file, type: planType, reason: 'ai_budget_exhausted' });
+      continue;
+    }
+
     // Generate suggestions
+    recordAiCall();
     const suggestion = await suggestThemeAndGoals(filePath, planType, dates.startDate, dates.endDate);
 
     if (suggestion && suggestion.theme && suggestion.goals && suggestion.goals.length > 0) {
@@ -3950,7 +3981,13 @@ async function suggestMissingSummaries(today) {
     const status = getPlanSummaryStatus(filePath, planType);
     if (!status || !status.isEmpty) continue;
 
+    if (aiBudgetExhausted()) {
+      results.skipped.push({ file, type: planType, reason: 'ai_budget_exhausted' });
+      continue;
+    }
+
     // Generate summary
+    recordAiCall();
     const summary = await generatePlanSummary(filePath, planType, dates.startDate, dates.endDate);
 
     if (summary) {
@@ -4282,6 +4319,8 @@ async function main() {
   if (!contextOnly) {
     const daysNeedingSummaries = getPastDaysNeedingSummaries(today, 7);
     for (const dayInfo of daysNeedingSummaries) {
+      if (aiBudgetExhausted()) break;
+      recordAiCall();
       const summary = await generateDailySummary(dayInfo.dateStr, dayInfo.path);
       if (summary) {
         addSummaryToFile(dayInfo.path, summary);
@@ -4293,7 +4332,8 @@ async function main() {
     }
 
     // Generate suggestions for tomorrow's plan if needed
-    if (needsPriorities(tomorrowPaths.day.path)) {
+    if (needsPriorities(tomorrowPaths.day.path) && !aiBudgetExhausted()) {
+      recordAiCall();
       const suggestions = await generateTomorrowSuggestions(tomorrowStr, tomorrowPaths.day.path);
       if (suggestions && updateTomorrowPlan(tomorrowPaths.day.path, suggestions)) {
         metadata.tomorrow_updated = true;
@@ -4345,6 +4385,14 @@ When the user asks what to work on, consider both their immediate daily prioriti
     context = `${guidance}\n\n${contextParts.join('\n\n---\n\n')}`;
   } else {
     context = 'No plan files found for the current period.';
+  }
+
+  if (aiCallsThisRun > 0 || aiCallsDeferred > 0) {
+    metadata.ai_calls = {
+      made: aiCallsThisRun,
+      deferred: aiCallsDeferred,
+      budget: maxAiCallsPerRun,
+    };
   }
 
   console.log(JSON.stringify({

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -607,12 +607,15 @@ function updateSyncMetadata(db, sourceId, filesProcessed, entriesCount, extraDat
 }
 
 const SYNC_LOCK_STALE_MINUTES = 5;
+// Refresh interval must comfortably fit within SYNC_LOCK_STALE_MINUTES so a
+// missed cycle doesn't cause the lock to be reclaimed by another caller.
+const SYNC_LOCK_HEARTBEAT_MS = 60 * 1000;
 
 /**
  * Try to acquire a sync lock for a source. Uses atomic UPDATE ... WHERE as a cross-process CAS.
  * Returns true if lock was acquired, false if another process holds it.
  */
-function tryAcquireSyncLock(db, sourceId, lockedBy) {
+export function tryAcquireSyncLock(db, sourceId, lockedBy) {
   // Ensure the row exists
   db.prepare(`INSERT OR IGNORE INTO sync_metadata (source) VALUES (?)`).run(sourceId);
 
@@ -630,12 +633,44 @@ function tryAcquireSyncLock(db, sourceId, lockedBy) {
 /**
  * Release a sync lock. Only releases if lockedBy matches to prevent releasing another process's lock.
  */
-function releaseSyncLock(db, sourceId, lockedBy) {
+export function releaseSyncLock(db, sourceId, lockedBy) {
   db.prepare(`
     UPDATE sync_metadata
     SET sync_locked_at = NULL, sync_locked_by = NULL
     WHERE source = ? AND sync_locked_by = ?
   `).run(sourceId, lockedBy);
+}
+
+/**
+ * Refresh a held lock's timestamp. Only updates if lockedBy still matches.
+ * Used to keep legitimately long-running syncs from being treated as stale.
+ */
+export function refreshSyncLock(db, sourceId, lockedBy) {
+  db.prepare(`
+    UPDATE sync_metadata
+    SET sync_locked_at = datetime('now')
+    WHERE source = ? AND sync_locked_by = ?
+  `).run(sourceId, lockedBy);
+}
+
+/**
+ * Start a heartbeat that refreshes the sync lock periodically. Returns a
+ * handle whose .stop() must be called in a finally block. Errors inside the
+ * interval are swallowed so a transient DB issue doesn't surface as an
+ * unhandled exception — the stale-lock recovery in tryAcquireSyncLock acts
+ * as the safety net.
+ */
+export function startSyncLockHeartbeat(db, sourceId, lockedBy) {
+  const handle = setInterval(() => {
+    try {
+      refreshSyncLock(db, sourceId, lockedBy);
+    } catch {
+      // Best-effort; stale-lock recovery will reclaim if heartbeats stop.
+    }
+  }, SYNC_LOCK_HEARTBEAT_MS);
+  // Don't keep the event loop alive just for the heartbeat.
+  if (typeof handle.unref === 'function') handle.unref();
+  return { stop: () => clearInterval(handle) };
 }
 
 /**
@@ -662,9 +697,11 @@ export async function syncPluginSource(plugin, sourceName, sourceConfig, context
     };
   }
 
+  const heartbeat = startSyncLockHeartbeat(db, sourceId, lockedBy);
   try {
     return await _syncPluginSourceInner(plugin, sourceName, sourceConfig, context, options, sourceId);
   } finally {
+    heartbeat.stop();
     releaseSyncLock(db, sourceId, lockedBy);
   }
 }

--- a/test/plugin-loader.test.js
+++ b/test/plugin-loader.test.js
@@ -40,7 +40,7 @@ function makeLockDb() {
       sync_locked_at TEXT,
       sync_locked_by TEXT,
       last_synced_at TEXT,
-      files_processed TEXT,
+      last_sync_files TEXT,
       entries_count INTEGER,
       extra_data TEXT
     )

--- a/test/plugin-loader.test.js
+++ b/test/plugin-loader.test.js
@@ -24,8 +24,29 @@ const {
   discoverPlugins,
   getPluginSources,
   getEnabledPlugins,
-  getPluginAccess
+  getPluginAccess,
+  tryAcquireSyncLock,
+  releaseSyncLock,
+  refreshSyncLock,
+  startSyncLockHeartbeat
 } = await import('../src/plugin-loader.js');
+const Database = (await import('better-sqlite3')).default;
+
+function makeLockDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE sync_metadata (
+      source TEXT PRIMARY KEY,
+      sync_locked_at TEXT,
+      sync_locked_by TEXT,
+      last_synced_at TEXT,
+      files_processed TEXT,
+      entries_count INTEGER,
+      extra_data TEXT
+    )
+  `);
+  return db;
+}
 
 describe('Plugin Loader', () => {
   beforeEach(() => {
@@ -143,6 +164,84 @@ describe('Plugin Loader', () => {
 
       expect(sources).toHaveLength(1);
       expect(sources[0].sourceName).toBe('local');
+    });
+  });
+
+  describe('sync lock', () => {
+    test('tryAcquireSyncLock succeeds on an unlocked source and blocks a second caller', () => {
+      const db = makeLockDb();
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'a:1')).toBe(true);
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(false);
+    });
+
+    test('releaseSyncLock only releases when lockedBy matches', () => {
+      const db = makeLockDb();
+      tryAcquireSyncLock(db, 'plugin/source', 'a:1');
+
+      // Wrong owner cannot release
+      releaseSyncLock(db, 'plugin/source', 'b:2');
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(false);
+
+      // Correct owner releases
+      releaseSyncLock(db, 'plugin/source', 'a:1');
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(true);
+    });
+
+    test('a lock older than the stale window is reclaimable (baseline behavior)', () => {
+      const db = makeLockDb();
+      tryAcquireSyncLock(db, 'plugin/source', 'a:1');
+      // Simulate the holder having been "stuck" for longer than the 5-minute stale window
+      db.prepare(`UPDATE sync_metadata SET sync_locked_at = datetime('now', '-6 minutes')`).run();
+
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(true);
+    });
+
+    test('refreshSyncLock pushes the timestamp forward so a stale lock is no longer reclaimable', () => {
+      const db = makeLockDb();
+      tryAcquireSyncLock(db, 'plugin/source', 'a:1');
+      db.prepare(`UPDATE sync_metadata SET sync_locked_at = datetime('now', '-6 minutes')`).run();
+
+      refreshSyncLock(db, 'plugin/source', 'a:1');
+
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(false);
+    });
+
+    test('refreshSyncLock is a no-op for a non-owner (prevents stealing)', () => {
+      const db = makeLockDb();
+      tryAcquireSyncLock(db, 'plugin/source', 'a:1');
+      db.prepare(`UPDATE sync_metadata SET sync_locked_at = datetime('now', '-6 minutes')`).run();
+
+      refreshSyncLock(db, 'plugin/source', 'b:2');
+
+      // The lock is still stale (b:2's refresh did nothing), so a third caller can reclaim
+      expect(tryAcquireSyncLock(db, 'plugin/source', 'c:3')).toBe(true);
+    });
+
+    test('startSyncLockHeartbeat fires refreshSyncLock on the configured interval and stops cleanly', () => {
+      jest.useFakeTimers();
+      try {
+        const db = makeLockDb();
+        tryAcquireSyncLock(db, 'plugin/source', 'a:1');
+
+        const handle = startSyncLockHeartbeat(db, 'plugin/source', 'a:1');
+
+        // Stale the timestamp, then let the heartbeat fire
+        db.prepare(`UPDATE sync_metadata SET sync_locked_at = datetime('now', '-6 minutes')`).run();
+        jest.advanceTimersByTime(60_000);
+
+        // Heartbeat refreshed the lock — another caller cannot acquire
+        expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(false);
+
+        handle.stop();
+        // After stop(), advancing time does not cause further refreshes
+        db.prepare(`UPDATE sync_metadata SET sync_locked_at = datetime('now', '-6 minutes')`).run();
+        jest.advanceTimersByTime(120_000);
+
+        // Lock is stale again, so it IS reclaimable
+        expect(tryAcquireSyncLock(db, 'plugin/source', 'b:2')).toBe(true);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #269

## Problem

The `markdown-plans` plugin was monopolizing local Ollama on the droplet — multiple invocations queued at once, each making minutes-long generations, blocking interactive use of the model indefinitely. Two distinct entry points (`bin/plugins sync` and `src/vault-watcher.js`) each fire the plugin; with no per-run cap on AI calls and a 5-minute sync-lock stale timeout that's shorter than a single CPU-Ollama plugin run, the lock got reclaimed mid-run and concurrent invocations ran in parallel.

Full background, evidence, and decision in #269.

## Changes

Three orthogonal fixes:

1. **Skip AI backlog drain on watcher-triggered runs.** When `vault-watcher` sets `FILE_FILTER` for a small set of changed files, `read.js` treats the run as context-only. Backlog draining belongs on manual `bin/plugins sync markdown-plans` or a scheduled run, not on every vault edit.
2. **Per-run AI call cap** (default 5, override via `max_ai_calls_per_run` in plugin.toml or `MARKDOWN_PLANS_MAX_AI_CALLS` env var). Bounds bulk runs so dozens of missing summaries get processed across several invocations instead of one giant queue. Skipped items report `ai_budget_exhausted`; `metadata.ai_calls` now reports `{ made, deferred, budget }` so callers see backlog size.
3. **Heartbeat the per-source sync lock** every 60s while a sync is in flight. `SYNC_LOCK_STALE_MINUTES = 5` is shorter than a single local-Ollama plugin run, which was letting the lock be reclaimed mid-run. The heartbeat keeps it alive as long as the parent process is; stale recovery still handles a crashed parent (parent dies → heartbeats stop → lock becomes reclaimable after 5 min).

## Tests

Added 6 new tests in `test/plugin-loader.test.js` covering:

- `tryAcquireSyncLock` blocks a second caller
- `releaseSyncLock` only releases on owner match
- A lock older than the stale window is reclaimable (baseline behavior preserved)
- `refreshSyncLock` pushes the timestamp forward so a stale lock is no longer reclaimable
- `refreshSyncLock` is a no-op for a non-owner (prevents stealing)
- `startSyncLockHeartbeat` fires `refreshSyncLock` on the configured interval and stops cleanly

Full suite (24 suites, 600 tests) passes.

## Out of scope

- `/_git/ai-commit-message` endpoint slowness — tracked separately in #268
- Switching this plugin's provider — orthogonal lever

🤖 Generated with [Claude Code](https://claude.com/claude-code)