### PR TITLE
fix(ai-provider): probe ~/.local/bin when which can't find the binary

### DIFF
--- a/bin/today
+++ b/bin/today
@@ -635,7 +635,8 @@ ${contextSection}`;
     const model = getInteractiveModel();
 
     // Check if this provider requires a binary and if it's installed
-    const { available, requirement } = checkProviderBinarySync(interactiveProvider, spawnSync);
+    const { available, requirement, binaryPath } = checkProviderBinarySync(interactiveProvider, spawnSync);
+    const claudeBinary = binaryPath || 'claude';
 
     if (!available && requirement) {
       console.error(`❌ ${requirement.name} not found.`);
@@ -659,7 +660,7 @@ ${contextSection}`;
         fs.writeFileSync(promptFile, prompt);
         const userMessage = directRequest || 'What should I focus on right now?';
         try {
-          const result = spawnSync('claude', ['--model', model, '--print', '--dangerously-skip-permissions', '--append-system-prompt-file', promptFile, userMessage], {
+          const result = spawnSync(claudeBinary, ['--model', model, '--print', '--dangerously-skip-permissions', '--append-system-prompt-file', promptFile, userMessage], {
             stdio: quiet ? ['pipe', 'pipe', 'pipe'] : 'inherit',
             timeout: 600000 // 10 minutes in milliseconds
           });
@@ -709,7 +710,7 @@ ${contextSection}`;
       fs.writeFileSync(promptFile, prompt);
       const userMessage = directRequest || 'What should I focus on right now?';
       try {
-        const claudeResult = spawnSync('claude', ['--model', model, '--append-system-prompt-file', promptFile, userMessage], { stdio: 'inherit' });
+        const claudeResult = spawnSync(claudeBinary, ['--model', model, '--append-system-prompt-file', promptFile, userMessage], { stdio: 'inherit' });
         if (claudeResult.error) {
           console.error(`ERROR: failed to launch claude: ${claudeResult.error.message}`);
           process.exit(1);

--- a/src/ai-provider.js
+++ b/src/ai-provider.js
@@ -26,6 +26,9 @@
 globalThis.AI_SDK_LOG_WARNINGS = false;
 
 import { generateText, streamText } from 'ai';
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
 import { getFullConfig } from './config.js';
 
 // Provider imports - these are loaded dynamically to avoid issues if not configured
@@ -609,7 +612,7 @@ export function getInteractiveProviderRequirements() {
  * Check if a provider's binary requirements are met (sync version for CLI use)
  * @param {string} providerName - The provider to check
  * @param {function} spawnSync - The spawnSync function to use
- * @returns {{ available: boolean, requirement?: object }}
+ * @returns {{ available: boolean, requirement?: object, binaryPath?: string }}
  */
 export function checkProviderBinarySync(providerName, spawnSync) {
   const requirement = INTERACTIVE_PROVIDER_REQUIREMENTS[providerName];
@@ -620,7 +623,18 @@ export function checkProviderBinarySync(providerName, spawnSync) {
   }
 
   const which = spawnSync('which', [requirement.binary], { encoding: 'utf8' });
-  const available = which.status === 0;
+  if (which.status === 0) {
+    const binaryPath = (which.stdout || '').trim() || requirement.binary;
+    return { available: true, requirement, binaryPath };
+  }
 
-  return { available, requirement };
+  // Fallback: ~/.local/bin is commonly missing from non-login PATHs
+  // (systemd units, cron, minimal SSH) but holds user-scoped installs
+  // like Claude Code's default location.
+  const localBinPath = join(homedir(), '.local', 'bin', requirement.binary);
+  if (existsSync(localBinPath)) {
+    return { available: true, requirement, binaryPath: localBinPath };
+  }
+
+  return { available: false, requirement };
 }

--- a/test/ai-provider.test.js
+++ b/test/ai-provider.test.js
@@ -14,7 +14,12 @@ const {
   getInteractiveProviderName,
   getInteractiveModel,
   getConfiguredModelName,
+  checkProviderBinarySync,
 } = await import('../src/ai-provider.js');
+
+const { existsSync } = await import('fs');
+const { homedir } = await import('os');
+const { join } = await import('path');
 
 describe('AI Provider (Vercel AI SDK)', () => {
   beforeEach(() => {
@@ -238,6 +243,50 @@ describe('AI Provider (Vercel AI SDK)', () => {
   describe('clearProviderCache', () => {
     test('can be called without error', () => {
       expect(() => clearProviderCache()).not.toThrow();
+    });
+  });
+
+  describe('checkProviderBinarySync', () => {
+    test('returns available with no requirement for API-only providers', () => {
+      const spawnSync = jest.fn();
+      const result = checkProviderBinarySync('anthropic-api', spawnSync);
+      expect(result).toEqual({ available: true });
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    test('returns resolved path when `which` finds the binary', () => {
+      const spawnSync = jest.fn().mockReturnValue({ status: 0, stdout: '/usr/local/bin/claude\n' });
+      const result = checkProviderBinarySync('anthropic', spawnSync);
+      expect(result.available).toBe(true);
+      expect(result.binaryPath).toBe('/usr/local/bin/claude');
+      expect(result.requirement.binary).toBe('claude');
+    });
+
+    test('falls back to ~/.local/bin when `which` fails but binary exists there', () => {
+      const localBinPath = join(homedir(), '.local', 'bin', 'claude');
+      const exists = existsSync(localBinPath);
+      const spawnSync = jest.fn().mockReturnValue({ status: 1, stdout: '' });
+      const result = checkProviderBinarySync('anthropic', spawnSync);
+      if (exists) {
+        expect(result.available).toBe(true);
+        expect(result.binaryPath).toBe(localBinPath);
+      } else {
+        expect(result.available).toBe(false);
+        expect(result.binaryPath).toBeUndefined();
+      }
+      expect(result.requirement.binary).toBe('claude');
+    });
+
+    test('returns unavailable when binary is missing everywhere', () => {
+      const spawnSync = jest.fn().mockReturnValue({ status: 1, stdout: '' });
+      const result = checkProviderBinarySync('ollama', spawnSync);
+      // ollama is unlikely to be at ~/.local/bin/ollama in CI; assert shape either way
+      const localBinPath = join(homedir(), '.local', 'bin', 'ollama');
+      if (!existsSync(localBinPath)) {
+        expect(result.available).toBe(false);
+        expect(result.binaryPath).toBeUndefined();
+      }
+      expect(result.requirement.binary).toBe('ollama');
     });
   });
 });


### PR DESCRIPTION
## Summary

- `checkProviderBinarySync` in `src/ai-provider.js` only consulted `which`, so any `bin/today` invocation without `~/.local/bin` on `PATH` (systemd, cron, minimal SSH) treated Claude Code as missing and aborted the interactive flow with `❌ Claude Code CLI not found.` — even when it was installed at `~/.local/bin/claude` (the default user-scoped install location).
- After `which` fails, we now probe `${HOME}/.local/bin/<binary>` and return the resolved `binaryPath`. The fallback is generic across all entries in `INTERACTIVE_PROVIDER_REQUIREMENTS` (claude, ollama, future ones).
- `bin/today` threads the resolved `binaryPath` into both `spawnSync('claude', …)` call sites so the launch actually succeeds when `PATH` is minimal.

Verified on the droplet — before the change, `checkProviderBinarySync('anthropic', …)` returned `available: false`; after, it returns `available: true, binaryPath: "/root/.local/bin/claude"`.

Fixes #282

## Test plan

- [x] `npm test -- test/ai-provider.test.js` (28 passed, including 4 new cases for the fallback)
- [ ] Re-run `bin/today` on the droplet and confirm it launches `claude` instead of erroring out

🤖 Generated with [Claude Code](https://claude.com/claude-code)