### PR TITLE
fix(configure): route TUI config writes through fs-atomic CAS

### DIFF
--- a/src/configure-toml-io.js
+++ b/src/configure-toml-io.js
@@ -1,0 +1,73 @@
+/**
+ * Shared TOML I/O for the configure TUIs.
+ *
+ * Both configure-ui.js and deployments-configure-ui.js write `today.toml`,
+ * and both must use compare-and-swap so a TUI session that opens before an
+ * external edit (eg. Unison merging in changes from another machine) does
+ * not clobber that edit when it saves.
+ */
+
+import fs from 'fs';
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+import { writeFileAtomicCAS } from './fs-atomic.js';
+
+const CONFIG_HEADER = `# Configuration for Today system
+# Edit this file when your situation changes (e.g., when traveling)
+
+`;
+
+/**
+ * Read config from `configPath`. Returns `{ config, raw }`; pass `raw` back
+ * to writeConfigToml() as the CAS baseline. When the file is missing, `raw`
+ * is `null` to match writeFileAtomicCAS's "no such file" sentinel — that way
+ * a first-time save (file created externally between read and write) is
+ * correctly flagged as a conflict.
+ */
+export function readConfigToml(configPath) {
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    return { config: parseToml(raw), raw };
+  } catch {
+    return { config: {}, raw: null };
+  }
+}
+
+/**
+ * Write config to `configPath` using compare-and-swap against `originalRaw`.
+ * Returns `{ content, conflict }`. On conflict the on-disk file is untouched;
+ * the caller is expected to surface the conflict to the user.
+ */
+export function writeConfigToml(configPath, config, originalRaw) {
+  let tomlOutput = stringifyToml(config);
+
+  // Convert ai_instructions back to triple-quoted multi-line strings
+  tomlOutput = tomlOutput.replace(
+    /^(ai_instructions\s*=\s*)"((?:[^"\\]|\\.)*)"/gm,
+    (match, prefix, content) => {
+      if (!content.includes('\\n')) return match;
+      const unescaped = content
+        .replace(/\\n/g, '\n')
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, '\\')
+        .trimEnd();
+      return `${prefix}"""\n${unescaped}\n"""`;
+    }
+  );
+
+  const newContent = CONFIG_HEADER + tomlOutput;
+  const { conflict } = writeFileAtomicCAS(configPath, newContent, originalRaw);
+  return { content: newContent, conflict };
+}
+
+/**
+ * Print a user-facing message explaining why a CAS write was refused.
+ * `source` is the human-readable name of the TUI that hit the conflict.
+ */
+export function reportConfigConflict(configPath, source) {
+  console.error('');
+  console.error(`❌ config.toml changed externally while ${source} was open.`);
+  console.error('   Your edits were NOT saved — refusing to overwrite newer content.');
+  console.error(`   File: ${configPath}`);
+  console.error('   Reopen configure to pick up the external changes and retry.');
+  console.error('');
+}

--- a/src/configure-toml-io.js
+++ b/src/configure-toml-io.js
@@ -8,6 +8,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import { writeFileAtomicCAS } from './fs-atomic.js';
 
@@ -27,9 +28,30 @@ export function readConfigToml(configPath) {
   try {
     const raw = fs.readFileSync(configPath, 'utf8');
     return { config: parseToml(raw), raw };
-  } catch {
-    return { config: {}, raw: null };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { config: {}, raw: null };
+    }
+    throw error;
   }
+}
+
+function getConfigFileLabel(configPath) {
+  return path.basename(configPath) || configPath;
+}
+
+/**
+ * Print a user-facing message explaining why a CAS write was refused.
+ * `source` is the human-readable name of the TUI that hit the conflict.
+ */
+export function reportConfigConflict(configPath, source) {
+  const configFileLabel = getConfigFileLabel(configPath);
+  console.error('');
+  console.error(`❌ ${configFileLabel} changed externally while ${source} was open.`);
+  console.error('   Your edits were NOT saved — refusing to overwrite newer content.');
+  console.error(`   File: ${configPath}`);
+  console.error('   Reopen configure to pick up the external changes and retry.');
+  console.error('');
 }
 
 /**
@@ -57,17 +79,4 @@ export function writeConfigToml(configPath, config, originalRaw) {
   const newContent = CONFIG_HEADER + tomlOutput;
   const { conflict } = writeFileAtomicCAS(configPath, newContent, originalRaw);
   return { content: newContent, conflict };
-}
-
-/**
- * Print a user-facing message explaining why a CAS write was refused.
- * `source` is the human-readable name of the TUI that hit the conflict.
- */
-export function reportConfigConflict(configPath, source) {
-  console.error('');
-  console.error(`❌ config.toml changed externally while ${source} was open.`);
-  console.error('   Your edits were NOT saved — refusing to overwrite newer content.');
-  console.error(`   File: ${configPath}`);
-  console.error('   Reopen configure to pick up the external changes and retry.');
-  console.error('');
 }

--- a/src/configure-ui.js
+++ b/src/configure-ui.js
@@ -13,7 +13,6 @@ import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import { discoverPlugins } from './plugin-loader.js';
 import { runPluginsConfigure } from './plugins-configure-ui.js';
 import { runDeploymentsConfigure } from './deployments-configure-ui.js';
@@ -25,6 +24,11 @@ import {
   getModelOptionsForProvider,
 } from './ai-settings-shared.js';
 import { getConfigPath, setConfigPath } from './config.js';
+import {
+  readConfigToml,
+  writeConfigToml,
+  reportConfigConflict as reportTomlConflict,
+} from './configure-toml-io.js';
 
 // Bind htm to React.createElement
 const html = htm.bind(React.createElement);
@@ -249,45 +253,9 @@ const CONFIG_SECTIONS = [
   },
 ];
 
-/**
- * Read config from file
- */
-function readConfig() {
-  try {
-    const content = fs.readFileSync(CONFIG_PATH, 'utf8');
-    return parseToml(content);
-  } catch {
-    return {};
-  }
-}
-
-/**
- * Write config to file
- */
-function writeConfig(config) {
-  let tomlOutput = stringifyToml(config);
-
-  // Convert ai_instructions to multi-line strings
-  tomlOutput = tomlOutput.replace(
-    /^(ai_instructions\s*=\s*)"((?:[^"\\]|\\.)*)"/gm,
-    (match, prefix, content) => {
-      if (!content.includes('\\n')) return match;
-      const unescaped = content
-        .replace(/\\n/g, '\n')
-        .replace(/\\"/g, '"')
-        .replace(/\\\\/g, '\\')
-        .trimEnd(); // Remove trailing whitespace to prevent accumulation
-      return `${prefix}"""\n${unescaped}\n"""`;
-    }
-  );
-
-  const header = `# Configuration for Today system
-# Edit this file when your situation changes (e.g., when traveling)
-
-`;
-
-  fs.writeFileSync(CONFIG_PATH, header + tomlOutput);
-}
+const readConfig = () => readConfigToml(CONFIG_PATH);
+const writeConfig = (config, originalRaw) => writeConfigToml(CONFIG_PATH, config, originalRaw);
+const reportConfigConflict = () => reportTomlConflict(CONFIG_PATH, 'configure');
 
 /**
  * Get a value from config using a path array
@@ -324,7 +292,18 @@ function setConfigValue(config, pathArr, value) {
  */
 function ConfigApp({ onAction, initialSection = 0 }) {
   const { exit } = useApp();
-  const [config, setConfig] = useState(() => readConfig());
+  const [configState, setConfigState] = useState(() => readConfig());
+  const { config, raw: originalRaw } = configState;
+
+  const persistConfig = (newConfig) => {
+    const { content, conflict } = writeConfig(newConfig, originalRaw);
+    if (conflict) {
+      reportConfigConflict();
+      exit();
+      process.exit(1);
+    }
+    setConfigState({ config: newConfig, raw: content });
+  };
   const [sectionIndex, setSectionIndex] = useState(initialSection);
   const [fieldIndex, setFieldIndex] = useState(0);
   const [mode, setMode] = useState('navigate'); // 'navigate', 'edit', 'select'
@@ -443,8 +422,8 @@ function ConfigApp({ onAction, initialSection = 0 }) {
     } else if (field.type === 'config-path') {
       // Save config path to .data/config-path
       setConfigPath(value);
-      // Re-read config from new location
-      setConfig(readConfig());
+      // Re-read config from new location (resets CAS baseline)
+      setConfigState(readConfig());
       setMode('navigate');
     } else {
       const newConfig = JSON.parse(JSON.stringify(config)); // Deep clone
@@ -457,8 +436,7 @@ function ConfigApp({ onAction, initialSection = 0 }) {
         setConfigValue(newConfig, ['ai', 'interactive_model'], '');
       }
 
-      writeConfig(newConfig);
-      setConfig(readConfig());
+      persistConfig(newConfig);
       setMode('navigate');
     }
   };
@@ -644,7 +622,7 @@ function ConfigApp({ onAction, initialSection = 0 }) {
  * Set a value in config using a path array (for use by runConfigure)
  */
 function setConfigValueAndSave(pathArr, value) {
-  const config = readConfig();
+  const { config, raw } = readConfig();
   let obj = config;
   for (let i = 0; i < pathArr.length - 1; i++) {
     const key = pathArr[i];
@@ -658,7 +636,11 @@ function setConfigValueAndSave(pathArr, value) {
   } else {
     obj[pathArr[pathArr.length - 1]] = value;
   }
-  writeConfig(config);
+  const { conflict } = writeConfig(config, raw);
+  if (conflict) {
+    reportConfigConflict();
+    process.exit(1);
+  }
 }
 
 export async function runConfigure() {

--- a/src/configure-ui.js
+++ b/src/configure-ui.js
@@ -36,7 +36,6 @@ const html = htm.bind(React.createElement);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.dirname(__dirname);
-const CONFIG_PATH = getConfigPath();
 const ENV_PATH = path.join(projectRoot, '.env');
 
 // ============================================================================
@@ -253,9 +252,9 @@ const CONFIG_SECTIONS = [
   },
 ];
 
-const readConfig = () => readConfigToml(CONFIG_PATH);
-const writeConfig = (config, originalRaw) => writeConfigToml(CONFIG_PATH, config, originalRaw);
-const reportConfigConflict = () => reportTomlConflict(CONFIG_PATH, 'configure');
+const readConfig = () => readConfigToml(getConfigPath());
+const writeConfig = (config, originalRaw) => writeConfigToml(getConfigPath(), config, originalRaw);
+const reportConfigConflict = () => reportTomlConflict(getConfigPath(), 'configure');
 
 /**
  * Get a value from config using a path array

--- a/src/deployments-configure-ui.js
+++ b/src/deployments-configure-ui.js
@@ -14,10 +14,14 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import { listProviders } from './deploy/providers/index.js';
 import { getIpEnvVarName } from './deploy/config.js';
 import { getConfigPath } from './config.js';
+import {
+  readConfigToml,
+  writeConfigToml,
+  reportConfigConflict as reportTomlConflict,
+} from './configure-toml-io.js';
 
 const html = htm.bind(React.createElement);
 
@@ -44,39 +48,9 @@ const PREDEFINED_JOBS = [
 // Config helpers
 // ============================================================================
 
-function readConfig() {
-  try {
-    const content = fs.readFileSync(CONFIG_PATH, 'utf8');
-    return parseToml(content);
-  } catch {
-    return {};
-  }
-}
-
-function writeConfig(config) {
-  // Preserve multiline strings
-  let tomlOutput = stringifyToml(config);
-
-  tomlOutput = tomlOutput.replace(
-    /^(ai_instructions\s*=\s*)"((?:[^"\\]|\\.)*)"/gm,
-    (match, prefix, content) => {
-      if (!content.includes('\\n')) return match;
-      const unescaped = content
-        .replace(/\\n/g, '\n')
-        .replace(/\\"/g, '"')
-        .replace(/\\\\/g, '\\')
-        .trimEnd();
-      return `${prefix}"""\n${unescaped}\n"""`;
-    }
-  );
-
-  const header = `# Configuration for Today system
-# Edit this file when your situation changes (e.g., when traveling)
-
-`;
-
-  fs.writeFileSync(CONFIG_PATH, header + tomlOutput);
-}
+const readConfig = () => readConfigToml(CONFIG_PATH);
+const writeConfig = (config, originalRaw) => writeConfigToml(CONFIG_PATH, config, originalRaw);
+const reportConfigConflict = () => reportTomlConflict(CONFIG_PATH, 'deployments configure');
 
 function getEnvVar(key) {
   try {
@@ -116,7 +90,7 @@ function setEnvVar(key, value) {
 // ============================================================================
 
 function getDeploymentsFromConfig() {
-  const config = readConfig();
+  const { config } = readConfig();
   const deploymentsConfig = config.deployments || {};
   const deployments = [];
 
@@ -145,6 +119,17 @@ function getDeploymentsFromConfig() {
 function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
   const { exit } = useApp();
   const [deployments, setDeployments] = useState(() => getDeploymentsFromConfig());
+
+  // CAS-protected save. Each handler is a short, synchronous read-modify-write,
+  // so call readConfig() right before mutating to keep the baseline tight.
+  const persistConfig = (config, originalRaw) => {
+    const { conflict } = writeConfig(config, originalRaw);
+    if (conflict) {
+      reportConfigConflict();
+      exit();
+      process.exit(1);
+    }
+  };
 
   // Determine initial state based on props
   const getInitialState = () => {
@@ -286,14 +271,14 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
           setMode('edit');
           setServiceIndex(0);
         } else {
-          const config = readConfig();
+          const { config, raw } = readConfig();
           if (config.deployments?.[selected.provider]?.[selected.name]) {
             if (!config.deployments[selected.provider][selected.name].services) {
               config.deployments[selected.provider][selected.name].services = {};
             }
             const current = config.deployments[selected.provider][selected.name].services[serviceKey] === true;
             config.deployments[selected.provider][selected.name].services[serviceKey] = !current;
-            writeConfig(config);
+            persistConfig(config, raw);
             refreshDeployments();
           }
         }
@@ -323,7 +308,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
         if (jobIndex < PREDEFINED_JOBS.length) {
           // Toggle predefined job
           const predefinedJob = PREDEFINED_JOBS[jobIndex];
-          const config = readConfig();
+          const { config, raw } = readConfig();
           if (config.deployments?.[selected.provider]?.[selected.name]) {
             if (!config.deployments[selected.provider][selected.name].jobs) {
               config.deployments[selected.provider][selected.name].jobs = {};
@@ -338,7 +323,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
                 description: predefinedJob.description
               };
             }
-            writeConfig(config);
+            persistConfig(config, raw);
             refreshDeployments();
           }
         } else if (jobIndex < PREDEFINED_JOBS.length + customJobEntries.length) {
@@ -437,7 +422,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
         } else if (field.key === '__save__') {
           // Validate and save
           if (newDeployment.jobName && newDeployment.command) {
-            const config = readConfig();
+            const { config, raw } = readConfig();
             if (config.deployments?.[selected.provider]?.[selected.name]) {
               if (!config.deployments[selected.provider][selected.name].jobs) {
                 config.deployments[selected.provider][selected.name].jobs = {};
@@ -447,7 +432,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
                 command: newDeployment.command,
                 description: newDeployment.jobName
               };
-              writeConfig(config);
+              persistConfig(config, raw);
               refreshDeployments();
             }
             setMode('jobs');
@@ -468,7 +453,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
 
   // Save a deployment setting
   const saveDeploymentSetting = (provider, name, key, value, nested) => {
-    const config = readConfig();
+    const { config, raw } = readConfig();
     if (!config.deployments) config.deployments = {};
     if (!config.deployments[provider]) config.deployments[provider] = {};
     if (!config.deployments[provider][name]) config.deployments[provider][name] = {};
@@ -498,13 +483,13 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
       }
     }
 
-    writeConfig(config);
+    persistConfig(config, raw);
     refreshDeployments();
   };
 
   // Create a new deployment
   const createDeployment = (provider, name) => {
-    const config = readConfig();
+    const { config, raw } = readConfig();
     if (!config.deployments) config.deployments = {};
     if (!config.deployments[provider]) config.deployments[provider] = {};
 
@@ -513,7 +498,7 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
       deploy_path: '/opt/today'
     };
 
-    writeConfig(config);
+    persistConfig(config, raw);
     refreshDeployments();
     setSelectedIndex(deployments.length); // Select the new one
     setMode('edit');
@@ -522,14 +507,14 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
 
   // Delete a deployment
   const deleteDeployment = (provider, name) => {
-    const config = readConfig();
+    const { config, raw } = readConfig();
     if (config.deployments?.[provider]?.[name]) {
       delete config.deployments[provider][name];
       if (Object.keys(config.deployments[provider]).length === 0) {
         delete config.deployments[provider];
       }
     }
-    writeConfig(config);
+    persistConfig(config, raw);
     refreshDeployments();
     setSelectedIndex(Math.max(0, selectedIndex - 1));
     setMode('list');
@@ -663,13 +648,13 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
             onChange=${(value) => {
               if (value === 'yes') {
                 // Delete the job
-                const config = readConfig();
+                const { config, raw } = readConfig();
                 if (config.deployments?.[selected.provider]?.[selected.name]?.jobs?.[editingJob.originalName]) {
                   delete config.deployments[selected.provider][selected.name].jobs[editingJob.originalName];
                   if (Object.keys(config.deployments[selected.provider][selected.name].jobs).length === 0) {
                     delete config.deployments[selected.provider][selected.name].jobs;
                   }
-                  writeConfig(config);
+                  persistConfig(config, raw);
                   refreshDeployments();
                   setJobIndex(i => Math.max(0, i - 1));
                 }
@@ -924,10 +909,10 @@ function DeploymentsConfigApp({ onExit, initialEdit, addNew }) {
                   // Update the editingJob state
                   setEditingJob(j => ({ ...j, [field.key]: value.trim() }));
                   // Save to config
-                  const config = readConfig();
+                  const { config, raw } = readConfig();
                   if (config.deployments?.[selected.provider]?.[selected.name]?.jobs?.[editingJob.originalName]) {
                     config.deployments[selected.provider][selected.name].jobs[editingJob.originalName][field.key] = value.trim();
-                    writeConfig(config);
+                    persistConfig(config, raw);
                     refreshDeployments();
                   }
                 }

--- a/src/deployments-configure-ui.js
+++ b/src/deployments-configure-ui.js
@@ -28,7 +28,6 @@ const html = htm.bind(React.createElement);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.dirname(__dirname);
-const CONFIG_PATH = getConfigPath();
 
 // ============================================================================
 // Predefined jobs that can be toggled on/off
@@ -48,9 +47,9 @@ const PREDEFINED_JOBS = [
 // Config helpers
 // ============================================================================
 
-const readConfig = () => readConfigToml(CONFIG_PATH);
-const writeConfig = (config, originalRaw) => writeConfigToml(CONFIG_PATH, config, originalRaw);
-const reportConfigConflict = () => reportTomlConflict(CONFIG_PATH, 'deployments configure');
+const readConfig = () => readConfigToml(getConfigPath());
+const writeConfig = (config, originalRaw) => writeConfigToml(getConfigPath(), config, originalRaw);
+const reportConfigConflict = () => reportTomlConflict(getConfigPath(), 'deployments configure');
 
 function getEnvVar(key) {
   try {

--- a/test/configure-toml-io.test.js
+++ b/test/configure-toml-io.test.js
@@ -136,7 +136,6 @@ describe('configure-toml-io', () => {
       expect(joined).toContain('today.toml changed externally');
       expect(joined).toContain('/tmp/today.toml');
       expect(joined).toContain('configure');
-      expect(joined).toMatch(/changed externally/i);
       errSpy.mockRestore();
     });
   });

--- a/test/configure-toml-io.test.js
+++ b/test/configure-toml-io.test.js
@@ -48,6 +48,11 @@ describe('configure-toml-io', () => {
       expect(config.profile.name).toBe('Test');
       expect(raw).toBe(content);
     });
+
+    test('rethrows parse errors for invalid TOML content', () => {
+      fs.writeFileSync(configPath, 'timezone = "UTC"\nbroken = [\n');
+      expect(() => readConfigToml(configPath)).toThrow();
+    });
   });
 
   describe('writeConfigToml', () => {
@@ -124,11 +129,12 @@ describe('configure-toml-io', () => {
   });
 
   describe('reportConfigConflict', () => {
-    test('writes a clear message to stderr including the path and source', () => {
+    test('uses the config filename in the conflict line and includes full path + source', () => {
       const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      reportConfigConflict('/tmp/example.toml', 'configure');
+      reportConfigConflict('/tmp/today.toml', 'configure');
       const joined = errSpy.mock.calls.map(args => args.join(' ')).join('\n');
-      expect(joined).toContain('/tmp/example.toml');
+      expect(joined).toContain('today.toml changed externally');
+      expect(joined).toContain('/tmp/today.toml');
       expect(joined).toContain('configure');
       expect(joined).toMatch(/changed externally/i);
       errSpy.mockRestore();

--- a/test/configure-toml-io.test.js
+++ b/test/configure-toml-io.test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for the shared configure-TUI TOML I/O helpers.
+ *
+ * The headline guarantee being verified here: writeConfigToml uses
+ * compare-and-swap, so a stale snapshot from a configure session that
+ * opened before an external edit will be refused (not silently overwrite
+ * the newer on-disk content).
+ */
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  readConfigToml,
+  writeConfigToml,
+  reportConfigConflict,
+} from '../src/configure-toml-io.js';
+
+function makeTmpPath() {
+  return path.join(os.tmpdir(), `configure-toml-io-${process.pid}-${Math.random().toString(36).slice(2)}.toml`);
+}
+
+describe('configure-toml-io', () => {
+  let configPath;
+
+  beforeEach(() => {
+    configPath = makeTmpPath();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(configPath)) fs.unlinkSync(configPath);
+  });
+
+  describe('readConfigToml', () => {
+    test('returns empty config and null raw when the file is missing', () => {
+      const { config, raw } = readConfigToml(configPath);
+      expect(config).toEqual({});
+      expect(raw).toBeNull();
+    });
+
+    test('returns parsed config and raw bytes for an existing file', () => {
+      const content = 'timezone = "America/New_York"\n\n[profile]\nname = "Test"\n';
+      fs.writeFileSync(configPath, content);
+
+      const { config, raw } = readConfigToml(configPath);
+      expect(config.timezone).toBe('America/New_York');
+      expect(config.profile.name).toBe('Test');
+      expect(raw).toBe(content);
+    });
+  });
+
+  describe('writeConfigToml', () => {
+    test('writes header + TOML and reports no conflict when baseline matches', () => {
+      const config = { timezone: 'UTC' };
+      const { content, conflict } = writeConfigToml(configPath, config, null);
+      expect(conflict).toBe(false);
+      expect(content.startsWith('# Configuration for Today system')).toBe(true);
+      expect(content).toContain('timezone = "UTC"');
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(content);
+    });
+
+    test('converts multi-line ai_instructions to triple-quoted strings', () => {
+      const config = {
+        plugins: { test: { default: { ai_instructions: 'Line 1\nLine 2' } } },
+      };
+      const { conflict } = writeConfigToml(configPath, config, null);
+      expect(conflict).toBe(false);
+
+      const written = fs.readFileSync(configPath, 'utf8');
+      expect(written).toContain('ai_instructions = """');
+      expect(written).toContain('Line 1');
+      expect(written).toContain('Line 2');
+    });
+
+    test('refuses to overwrite when on-disk content drifted from the baseline', () => {
+      const baseline = 'timezone = "UTC"\n';
+      fs.writeFileSync(configPath, baseline);
+
+      // Simulate an external writer (eg. Unison) merging in a change
+      // after the TUI read the file.
+      const drifted = 'timezone = "UTC"\nlocation = "Oakland Park"\n';
+      fs.writeFileSync(configPath, drifted);
+
+      const config = { timezone: 'America/New_York' };
+      const { conflict } = writeConfigToml(configPath, config, baseline);
+
+      expect(conflict).toBe(true);
+      // On-disk file is the externally-merged content, untouched.
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(drifted);
+    });
+
+    test('creates the file on first write when baseline is null', () => {
+      const config = { timezone: 'UTC' };
+      const { conflict } = writeConfigToml(configPath, config, null);
+      expect(conflict).toBe(false);
+      expect(fs.existsSync(configPath)).toBe(true);
+    });
+
+    test('treats a since-deleted file as a conflict when baseline was non-empty', () => {
+      const baseline = 'timezone = "UTC"\n';
+      // File never existed — caller thinks it had content, but disk says
+      // otherwise. CAS must refuse.
+      const config = { timezone: 'America/New_York' };
+      const { conflict } = writeConfigToml(configPath, config, baseline);
+      expect(conflict).toBe(true);
+      expect(fs.existsSync(configPath)).toBe(false);
+    });
+
+    test('round-trips a read + write when nothing else touches the file', () => {
+      const initial = 'timezone = "America/New_York"\n';
+      fs.writeFileSync(configPath, initial);
+
+      const { config, raw } = readConfigToml(configPath);
+      config.location = 'Oakland Park, Florida';
+
+      const { conflict } = writeConfigToml(configPath, config, raw);
+      expect(conflict).toBe(false);
+
+      const reloaded = readConfigToml(configPath);
+      expect(reloaded.config.timezone).toBe('America/New_York');
+      expect(reloaded.config.location).toBe('Oakland Park, Florida');
+    });
+  });
+
+  describe('reportConfigConflict', () => {
+    test('writes a clear message to stderr including the path and source', () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      reportConfigConflict('/tmp/example.toml', 'configure');
+      const joined = errSpy.mock.calls.map(args => args.join(' ')).join('\n');
+      expect(joined).toContain('/tmp/example.toml');
+      expect(joined).toContain('configure');
+      expect(joined).toMatch(/changed externally/i);
+      errSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`vault/today.toml` lost its deployment-specific AI sections twice this week. Root cause: the configure TUIs were missed by the anti-clobber work in #274.

- `src/configure-ui.js` and `src/deployments-configure-ui.js` both wrote `today.toml` with raw `fs.writeFileSync`, with no compare-and-swap against the bytes originally read.
- `configure-ui.js` is the worst case: it reads the file once on mount into long-lived React state and then re-serializes that entire snapshot on every save. So anything Unison merges in between \"open TUI\" and \"save\" gets silently dropped.

This PR:

- Factors the duplicated `readConfig` / `writeConfig` / conflict-reporting helpers out of both TUIs into a single `src/configure-toml-io.js`.
- Switches the writes to `writeFileAtomicCAS` with the originally-read content as the CAS baseline.
- On conflict, prints a clear stderr message naming the file and the TUI, calls ink's `exit()`, and `process.exit(1)`. The user re-opens configure to pick up the merged content and retries.
- `readConfigToml` returns `raw: null` (not `''`) for the missing-file case so it matches `writeFileAtomicCAS`'s missing-file sentinel — first-time saves still succeed.
- Adds `test/configure-toml-io.test.js` covering: missing file, parse, multi-line `ai_instructions` round-trip, header preservation, conflict-on-drift, first-write-on-null-baseline, deleted-since-read = conflict, and clean round-trip.

Net diff: +275 / -98 across 4 files. Removes duplication and gains direct test coverage of the CAS contract.

Fixes #285

## Test plan

- [x] `npm test` — full suite, 639 passed (29 suites)
- [x] `npm test -- test/configure-toml-io.test.js` — 9 new cases pass
- [x] Module-load smoke test for both refactored TUIs (`node -e \"import('./src/configure-ui.js')\"` etc.)
- [ ] Open \`bin/today configure\` on the droplet, edit something trivial, verify it saves
- [ ] Manually simulate a Unison-style race: open configure, externally edit `vault/today.toml`, save in TUI, confirm the clear conflict message and that the external edit is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)