### PR TITLE
fix(web): cache-bust /static URLs with deploy version

### DIFF
--- a/src/web-server.js
+++ b/src/web-server.js
@@ -66,6 +66,22 @@ marked.use({
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// Cache-busting version stamp for /static URLs. Computed once at startup
+// from the git HEAD short sha so each deploy invalidates browser caches
+// even though express.static still sends a long max-age. Falls back to a
+// boot timestamp if git is unavailable (eg. detached source dir).
+const STATIC_VERSION = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || Date.now().toString(36);
+  } catch {
+    return Date.now().toString(36);
+  }
+})();
+
 // Debug logging - set DEBUG=true in environment to enable verbose logging
 const DEBUG = process.env.DEBUG === 'true';
 const debug = (...args) => DEBUG && console.log('[DEBUG]', ...args);
@@ -109,6 +125,7 @@ function renderTemplate(template, data = {}) {
   const templateData = {
     themeToggleButton: getThemeToggleButtonHtml(),
     themeBootstrapScript: getThemeBootstrapScript(),
+    staticVersion: STATIC_VERSION,
     ...data,
   };
   for (const [key, value] of Object.entries(templateData)) {
@@ -372,13 +389,13 @@ ${getThemeBootstrapScript()}
 <!-- Highlight.js theme for code blocks -->
 <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" rel="stylesheet"/>
 <!-- Custom styles -->
-<link href="/static/css/style.css" rel="stylesheet"/>
+<link href="/static/css/style.css?v=${STATIC_VERSION}" rel="stylesheet"/>
 `;
 
 // Common scripts for all pages
 const pageScripts = `
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-<script src="/static/js/common.js"></script>
+<script src="/static/js/common.js?v=${STATIC_VERSION}"></script>
 `;
 
 // Scripts for pages with chat (includes marked.js for markdown)

--- a/src/web/templates/directory.html
+++ b/src/web/templates/directory.html
@@ -14,7 +14,7 @@
   <!-- Highlight.js theme for code blocks -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
 </head>
 <body>
   {{navbar}}
@@ -47,7 +47,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
   {{inlineScript}}
 </body>
 </html>

--- a/src/web/templates/error.html
+++ b/src/web/templates/error.html
@@ -12,7 +12,7 @@
   <!-- MDB -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
 </head>
 <body>
   <div class="container mt-5">
@@ -32,6 +32,6 @@
     </div>
   </div>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
 </body>
 </html>

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -12,7 +12,7 @@
   <!-- MDB -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
   {{head}}
 </head>
 <body>
@@ -42,7 +42,7 @@
   <!-- MDB -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
   <!-- Common scripts -->
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
   {{scripts}}
 </body>
 </html>

--- a/src/web/templates/markdown.html
+++ b/src/web/templates/markdown.html
@@ -14,7 +14,7 @@
   <!-- Highlight.js theme for code blocks -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
 </head>
 <body>
   {{navbar}}
@@ -62,7 +62,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
   {{inlineScript}}
 </body>
 </html>

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -14,7 +14,7 @@
   <!-- Highlight.js theme for code blocks -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
 </head>
 <body>
   {{navbar}}
@@ -38,6 +38,6 @@
   </div>
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
 </body>
 </html>

--- a/src/web/templates/task-detail.html
+++ b/src/web/templates/task-detail.html
@@ -14,7 +14,7 @@
   <!-- Highlight.js theme for code blocks -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" rel="stylesheet"/>
   <!-- Custom styles -->
-  <link href="/static/css/style.css" rel="stylesheet"/>
+  <link href="/static/css/style.css?v={{staticVersion}}" rel="stylesheet"/>
 </head>
 <body>
   {{navbar}}
@@ -75,6 +75,6 @@
     {{editFormScript}}
   </script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.1.0/mdb.umd.min.js"></script>
-  <script src="/static/js/common.js"></script>
+  <script src="/static/js/common.js?v={{staticVersion}}"></script>
 </body>
 </html>

--- a/test/static-cache-busting.test.js
+++ b/test/static-cache-busting.test.js
@@ -1,0 +1,62 @@
+/**
+ * Regression guard: every /static/<path> URL emitted by the web server must
+ * carry a cache-busting version query string. Without this, browsers serve
+ * stale assets for up to express.static's max-age (currently 1 day) after a
+ * deploy — which previously broke the theme toggle when the post-#258 HTML
+ * was loaded against the pre-#258 cached common.js (see #287).
+ *
+ * This test scans HTML templates and web-server.js for /static/ refs and
+ * asserts each one is followed by `?v={{staticVersion}}` (template) or
+ * `?v=${STATIC_VERSION}` (server-rendered HTML in web-server.js).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.join(__dirname, '..');
+const templatesDir = path.join(projectRoot, 'src', 'web', 'templates');
+const webServerPath = path.join(projectRoot, 'src', 'web-server.js');
+
+// Matches /static/<anything> followed by what comes next up to the closing quote.
+// We assert the full URL (with version) survives, so we capture everything up to
+// the closing quote / whitespace.
+const STATIC_URL_RE = /\/static\/[^"'\s>]*/g;
+
+function collectStaticUrls(text) {
+  return [...text.matchAll(STATIC_URL_RE)].map(match => match[0]);
+}
+
+describe('static asset cache busting', () => {
+  const templateFiles = fs.readdirSync(templatesDir)
+    .filter(f => f.endsWith('.html'))
+    .map(f => path.join(templatesDir, f));
+
+  test('every HTML template was discovered (at least one)', () => {
+    expect(templateFiles.length).toBeGreaterThan(0);
+  });
+
+  test.each(templateFiles)('%s: every /static/ ref carries ?v={{staticVersion}}', (file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    const urls = collectStaticUrls(content);
+    // Some templates legitimately have no static refs; only assert versioning
+    // on the ones that do.
+    for (const url of urls) {
+      expect(url).toMatch(/\?v=\{\{staticVersion\}\}$/);
+    }
+  });
+
+  test('web-server.js: every /static/ ref carries ?v=${STATIC_VERSION}', () => {
+    const content = fs.readFileSync(webServerPath, 'utf8');
+    const urls = collectStaticUrls(content);
+    // Filter out the express.static mount path itself — `/static` (no file)
+    // shows up as the mount route and should not have a version stamp.
+    const assetUrls = urls.filter(u => u !== '/static' && !u.endsWith('/static/'));
+    expect(assetUrls.length).toBeGreaterThan(0);
+    for (const url of assetUrls) {
+      expect(url).toMatch(/\?v=\$\{STATIC_VERSION\}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

After #258 merged, the theme toggle button appeared on the page but clicking did nothing. Root cause: \`express.static\` sends \`Cache-Control: max-age=86400\` on every \`/static\` asset (\`src/web-server.js\`), so browsers held the pre-#258 \`common.js\` for up to 24 hours. The post-#258 HTML rendered the toggle calling \`cycleThemeMode()\`, but the cached JS didn't define that function — inline \`onclick\` swallowed the ReferenceError, click went nowhere. Same hazard for any future change to \`common.js\`, \`style.css\`, or anything else served from \`/static\`.

This PR:

- Computes \`STATIC_VERSION\` once at server startup from \`git rev-parse --short HEAD\` (falls back to a base36 boot timestamp if git is unavailable, eg. detached source dir).
- Adds it as a default in \`renderTemplate\` (\`{{staticVersion}}\`) and inlines it into the \`pageStyle\` / \`pageScripts\` constants (\`\${STATIC_VERSION}\`).
- Updates the 14 \`/static/<file>\` references across the 6 HTML templates and the two \`pageStyle\`/\`pageScripts\` references in \`src/web-server.js\` to include \`?v=<version>\`.
- Keeps the long max-age (good for repeat visits within a deploy) while guaranteeing invalidation on the next deploy.

Adds \`test/static-cache-busting.test.js\` as a regression guard: scans every HTML template and \`web-server.js\` for \`/static/<path>\` URLs and asserts each carries the version stamp. Catches a future template adding an unversioned static ref.

Fixes #287

## Test plan

- [x] \`npm test\` — full suite, 653 passed (31 suites, including 10 new cache-busting cases)
- [x] \`npm test -- test/static-cache-busting.test.js\` — 10 cases pass
- [ ] After merge: \`bin/today web restart\` on the droplet, hit the site, confirm \`view-source\` shows \`/static/css/style.css?v=<sha>\` and \`/static/js/common.js?v=<sha>\`; click the theme toggle — should now work even without a hard-refresh on next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)