### PR TITLE
fix(markdown-tasks): never auto-consolidate; crash-safe rebalance with rename-backup

### DIFF
--- a/plugins/markdown-tasks/write.js
+++ b/plugins/markdown-tasks/write.js
@@ -1027,30 +1027,36 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
       }
     }
 
-    if (allTasks.length > 0) {
+    // Only rebalance when an existing file actually overflows. Auto-consolidating
+    // underflow into a single file (the previous behavior) silently deletes
+    // numbered files even when the user is still using them, which is the
+    // bug tracked in #289.
+    const anyFileOverflows = filesToRebalance.some(f => {
+      if (!fs.existsSync(f)) return false;
+      const taskCount = fs.readFileSync(f, 'utf8').split('\n').filter(line => line.trim()).length;
+      return taskCount > maxTasksPerFile;
+    });
+
+    if (allTasks.length > 0 && anyFileOverflows) {
 
         // Sort tasks alphabetically (case-insensitive) so they distribute a-z across files
         allTasks.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
-        // Calculate number of files needed
-        const numFilesNeeded = Math.ceil(allTasks.length / maxTasksPerFile);
+        // Calculate number of files needed. Never go below the existing count —
+        // we only split forward; we don't consolidate underflow.
+        const minFilesNeeded = Math.ceil(allTasks.length / maxTasksPerFile);
+        const numFilesNeeded = Math.max(minFilesNeeded, 1 + numberedFiles.length);
 
         // Get existing numbered file numbers
         const existingNums = numberedFiles
           .map(f => parseInt(path.basename(f).match(numberedFilePattern)[1]))
           .sort((a, b) => a - b);
 
-        // Generate file numbers we need (starting from 1 if we need extra files)
-        const targetFileNums = [];
-        if (numFilesNeeded > 1) {
-          // We need numbered files for overflow
-          for (let i = 1; i < numFilesNeeded; i++) {
-            targetFileNums.push(i);
-          }
-        }
-
-        // Ensure we have enough file numbers
-        let nextNum = Math.max(0, ...existingNums, ...targetFileNums) + 1;
+        // Always rewrite every existing numbered file (so its content is part of
+        // the redistribution and we don't end up with duplicates); add new file
+        // numbers for any extra files we need beyond what exists.
+        const targetFileNums = [...existingNums];
+        let nextNum = Math.max(0, ...existingNums) + 1;
         while (targetFileNums.length < numFilesNeeded - 1) {
           targetFileNums.push(nextNum++);
         }
@@ -1058,53 +1064,73 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
         // Distribute tasks across files
         const filesToWrite = [];
 
+        // Spread tasks evenly across the available files so no single file is
+        // anywhere near `maxTasksPerFile` after the rebalance.
+        const perFile = Math.ceil(allTasks.length / numFilesNeeded);
+
         // Main file gets first chunk
-        const mainChunk = allTasks.slice(0, maxTasksPerFile);
+        const mainChunk = allTasks.slice(0, perFile);
         filesToWrite.push({
           path: taskFile,
           tasks: mainChunk,
           name: path.basename(taskFile)
         });
 
-        // Remaining tasks go to numbered files
-        let taskIndex = maxTasksPerFile;
+        // Remaining tasks go to numbered files (every existing one + any extras)
+        let taskIndex = perFile;
         for (const fileNum of targetFileNums) {
           const filePath = path.join(taskDir, `${taskBaseName}-${fileNum}.md`);
-          const chunk = allTasks.slice(taskIndex, taskIndex + maxTasksPerFile);
+          const chunk = allTasks.slice(taskIndex, taskIndex + perFile);
 
-          if (chunk.length > 0) {
-            filesToWrite.push({
-              path: filePath,
-              tasks: chunk,
-              name: path.basename(filePath)
-            });
-            taskIndex += maxTasksPerFile;
-          }
-        }
-
-        // Clean up old numbered files first (we'll recreate what we need)
-        for (const filePath of numberedFiles) {
-          try {
-            fs.unlinkSync(filePath);
-            filesModified.add(path.relative(projectRoot, filePath));
-          } catch {
-            // File might not exist, continue
-          }
-        }
-
-        // Write all files with new distribution. These targets were just unlinked
-        // above (or are the main task file being overwritten with a fresh chunk),
-        // so CAS isn't meaningful — atomic write is enough to keep readers from
-        // observing a torn file mid-rebalance.
-        const distributionInfo = [];
-        for (const fileInfo of filesToWrite) {
-          writeFileAtomic(fileInfo.path, fileInfo.tasks.join('\n') + '\n');
-          filesModified.add(path.relative(projectRoot, fileInfo.path));
-
-          distributionInfo.push({
-            file: fileInfo.name,
-            task_count: fileInfo.tasks.length
+          filesToWrite.push({
+            path: filePath,
+            tasks: chunk,
+            name: path.basename(filePath)
           });
+          taskIndex += perFile;
+        }
+
+        // Crash-safe write: rename each target to a .rebalance-bak-<ts> first,
+        // then write the new distribution, then drop the backups. If a write
+        // throws, restore the backups so the vault is never left with deleted-
+        // but-unreplaced files. unlinkSync was the previous behavior — it left
+        // a window where an interrupted run could lose data.
+        const backups = [];
+        const rebalanceTs = Date.now();
+        for (const fileInfo of filesToWrite) {
+          if (fs.existsSync(fileInfo.path)) {
+            const backupPath = `${fileInfo.path}.rebalance-bak-${rebalanceTs}`;
+            try {
+              fs.renameSync(fileInfo.path, backupPath);
+              backups.push({ original: fileInfo.path, backup: backupPath });
+            } catch {
+              // File vanished between exists() and rename(); skip.
+            }
+          }
+        }
+
+        const distributionInfo = [];
+        try {
+          for (const fileInfo of filesToWrite) {
+            writeFileAtomic(fileInfo.path, fileInfo.tasks.join('\n') + '\n');
+            filesModified.add(path.relative(projectRoot, fileInfo.path));
+
+            distributionInfo.push({
+              file: fileInfo.name,
+              task_count: fileInfo.tasks.length
+            });
+          }
+        } catch (writeError) {
+          // Roll back: restore originals from backups before re-throwing.
+          for (const { original, backup } of backups) {
+            try { fs.renameSync(backup, original); } catch { /* best effort */ }
+          }
+          throw writeError;
+        }
+
+        // All writes succeeded — drop the backups.
+        for (const { backup } of backups) {
+          try { fs.unlinkSync(backup); } catch { /* best effort */ }
         }
 
         rebalanced = true;

--- a/plugins/markdown-tasks/write.js
+++ b/plugins/markdown-tasks/write.js
@@ -9,6 +9,7 @@
 // - complete: Mark a task as completed
 // - update: Update a task's properties
 
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
@@ -1096,15 +1097,21 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
         // but-unreplaced files. unlinkSync was the previous behavior — it left
         // a window where an interrupted run could lose data.
         const backups = [];
-        const rebalanceTs = Date.now();
+        const rebalanceSuffix = `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
         for (const fileInfo of filesToWrite) {
           if (fs.existsSync(fileInfo.path)) {
-            const backupPath = `${fileInfo.path}.rebalance-bak-${rebalanceTs}`;
+            const backupPath = `${fileInfo.path}.rebalance-bak-${rebalanceSuffix}`;
             try {
               fs.renameSync(fileInfo.path, backupPath);
               backups.push({ original: fileInfo.path, backup: backupPath });
-            } catch {
-              // File vanished between exists() and rename(); skip.
+            } catch (renameError) {
+              if (renameError.code === 'ENOENT') {
+                // File vanished between exists() and rename(); safe to skip.
+              } else {
+                // Permission error, destination collision, etc. — abort the
+                // entire rebalance so we never write a file we can't roll back.
+                throw renameError;
+              }
             }
           }
         }

--- a/plugins/markdown-tasks/write.js
+++ b/plugins/markdown-tasks/write.js
@@ -1135,11 +1135,6 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
             }
           }
           for (const { original, backup } of backups) {
-            try {
-              if (fs.existsSync(original)) fs.unlinkSync(original);
-            } catch {
-              // Best effort cleanup before backup restore.
-            }
             try { fs.renameSync(backup, original); } catch { /* best effort */ }
           }
           throw writeError;

--- a/plugins/markdown-tasks/write.js
+++ b/plugins/markdown-tasks/write.js
@@ -1110,9 +1110,11 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
         }
 
         const distributionInfo = [];
+        const writtenPaths = [];
         try {
           for (const fileInfo of filesToWrite) {
             writeFileAtomic(fileInfo.path, fileInfo.tasks.join('\n') + '\n');
+            writtenPaths.push(fileInfo.path);
             filesModified.add(path.relative(projectRoot, fileInfo.path));
 
             distributionInfo.push({
@@ -1121,8 +1123,23 @@ ${JSON.stringify(batch.map((t, idx) => ({ index: idx, title: t.title })), null, 
             });
           }
         } catch (writeError) {
-          // Roll back: restore originals from backups before re-throwing.
+          // Roll back: remove any newly written distribution files, then restore
+          // originals from backups before re-throwing. Without removing the
+          // successful writes first, a later failure can leave brand-new
+          // numbered files behind beside the restored originals.
+          for (const filePath of writtenPaths) {
+            try {
+              if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+            } catch {
+              // Best effort cleanup before backup restore.
+            }
+          }
           for (const { original, backup } of backups) {
+            try {
+              if (fs.existsSync(original)) fs.unlinkSync(original);
+            } catch {
+              // Best effort cleanup before backup restore.
+            }
             try { fs.renameSync(backup, original); } catch { /* best effort */ }
           }
           throw writeError;

--- a/test/markdown-tasks-write.test.js
+++ b/test/markdown-tasks-write.test.js
@@ -191,4 +191,30 @@ describe('markdown-tasks/write.js (fs-atomic rollout)', () => {
     expect(result.success).toBe(true);
     expect(fs.existsSync(overflowPath)).toBe(true);
   });
+
+  test('archive-completed rollback removes partial writes before restoring backups', () => {
+    fs.mkdirSync(path.dirname(tasksFile), { recursive: true });
+    fs.writeFileSync(tasksFile, '- [ ] Bravo\n- [ ] Alpha\n- [ ] Echo\n');
+    const overflowPath = path.join(path.dirname(tasksFile), 'tasks-1.md');
+    fs.writeFileSync(overflowPath, '- [ ] Delta\n- [ ] Charlie\n');
+
+    // Force the final write in the rebalance to fail after earlier files have
+    // already been rewritten.
+    const blockedPath = path.join(path.dirname(tasksFile), 'tasks-2.md');
+    fs.mkdirSync(blockedPath);
+
+    const beforeMain = fs.readFileSync(tasksFile, 'utf8');
+    const beforeOverflow = fs.readFileSync(overflowPath, 'utf8');
+
+    const result = runWrite(
+      { action: 'archive-completed', max_tasks_per_file: 2 },
+      { vaultPath }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Failed to write');
+    expect(fs.readFileSync(tasksFile, 'utf8')).toBe(beforeMain);
+    expect(fs.readFileSync(overflowPath, 'utf8')).toBe(beforeOverflow);
+    expect(fs.readdirSync(path.dirname(tasksFile)).filter(f => f.includes('.rebalance-bak-'))).toEqual([]);
+  });
 });

--- a/test/markdown-tasks-write.test.js
+++ b/test/markdown-tasks-write.test.js
@@ -125,4 +125,70 @@ describe('markdown-tasks/write.js (fs-atomic rollout)', () => {
     // New field added by the rollout — present even when nothing conflicted.
     expect(Array.isArray(result.files_skipped_due_to_conflict)).toBe(true);
   });
+
+  // Regression coverage for #289 — the rebalance used to auto-consolidate
+  // every numbered file into the main file whenever total tasks fit there,
+  // silently deleting tasks-1.md (and other numbered siblings) multiple
+  // times a day on busy vaults. It also did the deletion via an unguarded
+  // fs.unlinkSync before writing the new distribution, leaving a window
+  // where a crash mid-rebalance lost the deleted content entirely.
+  test('archive-completed does NOT delete tasks-1.md when underflow could consolidate', () => {
+    // Set up: main file has 1 task, tasks-1.md has 1 task. Together they
+    // fit easily inside the default max_tasks_per_file (50), so the old
+    // code would have consolidated and deleted tasks-1.md.
+    fs.mkdirSync(path.dirname(tasksFile), { recursive: true });
+    fs.writeFileSync(tasksFile, '- [ ] Main task\n');
+    const overflowPath = path.join(path.dirname(tasksFile), 'tasks-1.md');
+    fs.writeFileSync(overflowPath, '- [ ] Overflow task\n');
+
+    const result = runWrite({ action: 'archive-completed' }, { vaultPath });
+
+    expect(result.success).toBe(true);
+    expect(result.rebalanced).toBe(false);
+    expect(fs.existsSync(overflowPath)).toBe(true);
+    expect(fs.readFileSync(overflowPath, 'utf8')).toContain('- [ ] Overflow task');
+  });
+
+  test('archive-completed splits forward when main file overflows', () => {
+    fs.mkdirSync(path.dirname(tasksFile), { recursive: true });
+    // 5 tasks with max_tasks_per_file = 2 => 3 files needed (main + 2 numbered).
+    const overflowTasks = Array.from({ length: 5 }, (_, i) => `- [ ] Task ${i + 1}`).join('\n') + '\n';
+    fs.writeFileSync(tasksFile, overflowTasks);
+
+    const result = runWrite(
+      { action: 'archive-completed', max_tasks_per_file: 2 },
+      { vaultPath }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.rebalanced).toBe(true);
+
+    // Main file and at least one new numbered file should now exist, and
+    // every file should be within the max.
+    const tasksDir = path.dirname(tasksFile);
+    const taskFiles = fs.readdirSync(tasksDir).filter(f => /^tasks(-\d+)?\.md$/.test(f));
+    expect(taskFiles.length).toBeGreaterThanOrEqual(2);
+    for (const f of taskFiles) {
+      const lineCount = fs.readFileSync(path.join(tasksDir, f), 'utf8').split('\n').filter(line => line.trim()).length;
+      expect(lineCount).toBeLessThanOrEqual(2);
+    }
+
+    // No backup files left over after a successful rebalance.
+    const backups = fs.readdirSync(tasksDir).filter(f => f.includes('.rebalance-bak-'));
+    expect(backups).toEqual([]);
+  });
+
+  test('archive-completed preserves existing numbered files when no overflow', () => {
+    // Pre-create an empty tasks-1.md — a no-overflow run should leave it
+    // alone rather than deleting it.
+    fs.mkdirSync(path.dirname(tasksFile), { recursive: true });
+    fs.writeFileSync(tasksFile, '- [ ] Single task\n');
+    const overflowPath = path.join(path.dirname(tasksFile), 'tasks-1.md');
+    fs.writeFileSync(overflowPath, '');
+
+    const result = runWrite({ action: 'archive-completed' }, { vaultPath });
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(overflowPath)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

The \`archive-completed\` rebalance in \`plugins/markdown-tasks/write.js:1004-1108\` was deleting \`vault/tasks/tasks-1.md\` multiple times a day with no underlying overflow. Two distinct problems, both fixed here:

### 1. Auto-consolidation deleted numbered files on underflow

When total tasks fit in fewer files than currently exist (very common — every time the total dropped below \`maxTasksPerFile = 50\`), the rebalance:

- Computed \`numFilesNeeded = ceil(allTasks / max)\` — often 1
- Unconditionally \`fs.unlinkSync()\` every numbered file (\`tasks-1.md\`, \`tasks-2.md\`, …)
- Wrote a single consolidated \`tasks.md\`

User observation: \`tasks-1.md\` reappeared and was deleted repeatedly because something else kept re-creating it.

**Fix:** only run the rebalance when an existing file actually overflows \`maxTasksPerFile\`. When the rebalance does run, never reduce the file count:
\`\`\`js
const numFilesNeeded = Math.max(minFilesNeeded, 1 + numberedFiles.length);
\`\`\`
Existing \`tasks-N.md\` files are rewritten with their share of the redistributed tasks, never dropped.

### 2. Unguarded delete-then-write window

The old code did \`fs.unlinkSync()\` first, then \`writeFileAtomic()\` second. A crash, OOM, or filesystem error in between left the vault with deleted-but-unreplaced numbered files. CAS on the new write doesn't help — the deletion already happened.

**Fix:** two-phase rename-backup:
1. Rename each target file to \`<path>.rebalance-bak-<ts>\` (atomic rename).
2. Write the new distribution. If any write throws, rename backups back to originals and re-throw.
3. Only after every write succeeds, unlink the backups.

### Side benefit: tasks now distribute evenly

Instead of \`first maxTasksPerFile to main, next chunk to next file\`, the rebalance now uses \`perFile = ceil(total / numFilesNeeded)\` so no file is anywhere near the max after rebalance. Less likely to ping-pong rebalances on the next add.

## Test plan

- [x] \`npm test\` — full suite, 656 passed (31 suites)
- [x] \`npm test -- test/markdown-tasks-write.test.js\` — 8 cases pass, including 3 new regression cases for #289:
  - \`archive-completed does NOT delete tasks-1.md when underflow could consolidate\`
  - \`archive-completed splits forward when main file overflows\` (and verifies no \`.rebalance-bak-*\` leftovers)
  - \`archive-completed preserves existing numbered files when no overflow\`

Fixes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)