### PR TITLE
fix(ai-chat): CAS-protect edit_file tool's search-and-replace (part of #291)

### DIFF
--- a/src/ai-chat/tools.js
+++ b/src/ai-chat/tools.js
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import fs from 'fs/promises';
 import path from 'path';
 import { spawn } from 'child_process';
+import { writeFileAtomicCASAsync } from '../fs-atomic.js';
 import { getAbsoluteVaultPath, getFullConfig } from '../config.js';
 import { schemas, getTableName } from '../plugin-schemas.js';
 
@@ -161,8 +162,17 @@ export function createEditFileTool(filePath) {
         // Perform the replacement
         const newContent = replaceAll ? currentContent.replaceAll(oldText, newText) : currentContent.replace(oldText, newText);
 
-        // Write the updated content
-        await fs.writeFile(resolvedPath, newContent, 'utf-8');
+        // Compare-and-swap write so a concurrent edit (another tool call, the
+        // file save endpoint, or a vault sync writing in from another box)
+        // between our read and our write doesn't get silently clobbered.
+        const { conflict } = await writeFileAtomicCASAsync(resolvedPath, newContent, currentContent);
+        if (conflict) {
+          return {
+            success: false,
+            conflict: true,
+            error: 'The file changed under us between read and write. Re-read the file and retry the edit against the fresh content.',
+          };
+        }
 
         // Verify the change was made
         const verificationContent = await fs.readFile(resolvedPath, 'utf-8');

--- a/test/ai-chat-edit-file-tool.test.js
+++ b/test/ai-chat-edit-file-tool.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for the edit_file AI tool's compare-and-swap behavior.
+ *
+ * Regression coverage for #291: the tool used to do a read-modify-write
+ * with plain fs.writeFile, so a concurrent edit between the read and the
+ * write was silently overwritten. The fix uses writeFileAtomicCASAsync
+ * with currentContent as the baseline, returning conflict to the AI
+ * runner so it can re-read and retry.
+ */
+
+import { jest } from '@jest/globals';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Mock the config module so getAbsoluteVaultPath returns our temp dir.
+let tempVault;
+jest.unstable_mockModule('../src/config.js', () => ({
+  getAbsoluteVaultPath: () => tempVault,
+  getFullConfig: () => ({}),
+}));
+
+const { createEditFileTool } = await import('../src/ai-chat/tools.js');
+
+describe('edit_file tool CAS behavior', () => {
+  let filePath;
+
+  beforeEach(() => {
+    tempVault = fsSync.mkdtempSync(path.join(os.tmpdir(), 'edit-file-cas-'));
+    filePath = path.join(tempVault, 'notes', 'plan.md');
+    fsSync.mkdirSync(path.dirname(filePath), { recursive: true });
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(tempVault, { recursive: true, force: true });
+  });
+
+  test('happy path: applies a single replacement and reports success', async () => {
+    await fs.writeFile(filePath, 'Hello, world!\n');
+
+    const result = await createEditFileTool(filePath).execute({
+      oldText: 'world',
+      newText: 'universe',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementsMade).toBe(1);
+    expect(await fs.readFile(filePath, 'utf-8')).toBe('Hello, universe!\n');
+  });
+
+  test('reports conflict instead of clobbering when file changes mid-edit', async () => {
+    await fs.writeFile(filePath, 'original baseline\n');
+
+    // Spy on fs.readFile so we can simulate a concurrent writer that
+    // modifies the file AFTER the tool reads currentContent but BEFORE the
+    // CAS write attempts the atomic rename.
+    const realReadFile = fs.readFile.bind(fs);
+    const spy = jest.spyOn(fs, 'readFile').mockImplementationOnce(async (...args) => {
+      const value = await realReadFile(...args);
+      // Concurrent writer wins the race: rewrites the file under us.
+      await realReadFile(filePath, 'utf-8'); // settle
+      fsSync.writeFileSync(filePath, 'concurrent edit\n');
+      return value;
+    });
+
+    const result = await createEditFileTool(filePath).execute({
+      oldText: 'original',
+      newText: 'mine',
+    });
+
+    spy.mockRestore();
+
+    expect(result.success).toBe(false);
+    expect(result.conflict).toBe(true);
+    // The concurrent edit is preserved untouched.
+    expect(await fs.readFile(filePath, 'utf-8')).toBe('concurrent edit\n');
+  });
+
+  test('refuses replaceAll-less call when oldText appears multiple times', async () => {
+    await fs.writeFile(filePath, 'foo bar foo baz\n');
+
+    const result = await createEditFileTool(filePath).execute({
+      oldText: 'foo',
+      newText: 'qux',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('2 times');
+    // File untouched.
+    expect(await fs.readFile(filePath, 'utf-8')).toBe('foo bar foo baz\n');
+  });
+
+  test('replaceAll: true applies and CAS-protects multi-occurrence edits', async () => {
+    await fs.writeFile(filePath, 'foo bar foo baz\n');
+
+    const result = await createEditFileTool(filePath).execute({
+      oldText: 'foo',
+      newText: 'qux',
+      replaceAll: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementsMade).toBe(2);
+    expect(await fs.readFile(filePath, 'utf-8')).toBe('qux bar qux baz\n');
+  });
+});


### PR DESCRIPTION
## Summary

The \`edit_file\` AI tool (\`src/ai-chat/tools.js:122\`) did a read-modify-write using a bare \`fs.writeFile\`. A concurrent edit landing between the tool's read at line 141 and write at line 165 — another tool call from a parallel AI session, the file-save endpoint, or Unison syncing in a change from another machine — was silently overwritten with the stale-baseline result.

The baseline was already in scope (\`currentContent\`), so the CAS retrofit is small:

\`\`\`js
const { conflict } = await writeFileAtomicCASAsync(resolvedPath, newContent, currentContent);
if (conflict) {
  return {
    success: false,
    conflict: true,
    error: 'The file changed under us between read and write. Re-read the file and retry the edit against the fresh content.',
  };
}
\`\`\`

Returning the conflict flag back to the AI runner lets the model re-read and retry against fresh content instead of clobbering.

## Scope note

Two other AI write paths cited in #291 — \`/ai-edit/*path\` (\`web-server.js:6124\`) and the file-save endpoint (\`web-server.js:7222\`) — are NOT touched by this PR. Both write a full content payload sent by the client with no baseline, and both already have a handler comment acknowledging the limitation:

> *"AI-edit endpoints don't carry an expected-content basis from the client, so we use atomic-only writes (no CAS)"*

Adding CAS there needs an \`If-Match\`-style client contract and a coordinated UI rollout. Tracked as Wave B in #291.

## Test plan

- [x] \`npm test\` — full suite, 657 passed (32 suites)
- [x] \`npm test -- test/ai-chat-edit-file-tool.test.js\` — 4 cases pass:
  - happy-path single replacement
  - conflict detected and surfaced (concurrent writer wins, AI tool reports \`success: false, conflict: true\`, on-disk content is preserved)
  - multi-occurrence refused without \`replaceAll\`
  - \`replaceAll: true\` succeeds with CAS still in effect

Fixes part of #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)