### PR TITLE
fix(save-route): harden traversal guard, fix postWriteHook JSDoc, add sibling-prefix regression test

### DIFF
--- a/src/save-route.js
+++ b/src/save-route.js
@@ -1,0 +1,99 @@
+/**
+ * POST /save/*path handler factory.
+ *
+ * Extracted from web-server.js so the If-Match/CAS contract can be exercised
+ * in unit tests without booting the full app. See issue #293.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import { writeFileAtomicCASAsync } from './fs-atomic.js';
+
+/**
+ * @param {object} opts
+ * @param {string} opts.vaultPath - Absolute path to the vault root.
+ * @param {(filePath: string) => Promise<{ok: true, file: string} | {ok: false, reason: string}>} [opts.postWriteHook]
+ *   Optional hook fired after a successful write — used by the live server to
+ *   log; tests can pass a recorder.
+ */
+export function createSaveHandler({ vaultPath, postWriteHook } = {}) {
+  if (!vaultPath) throw new Error('createSaveHandler: vaultPath is required');
+
+  return async function saveHandler(req, res) {
+    try {
+      const urlPath = Array.isArray(req.params.path)
+        ? req.params.path.join('/')
+        : req.params.path;
+      let fullPath = path.join(vaultPath, urlPath);
+
+      // Security: prevent directory traversal
+      if (!fullPath.startsWith(vaultPath)) {
+        return res.status(403).send('Access denied');
+      }
+
+      // If path has no extension, try adding .md (Obsidian-style URLs)
+      if (!path.extname(urlPath)) {
+        fullPath = fullPath + '.md';
+        if (!fullPath.startsWith(vaultPath)) {
+          return res.status(403).send('Access denied');
+        }
+      }
+
+      const stats = await fs.stat(fullPath);
+      if (!stats.isFile() || (!fullPath.endsWith('.md') && !fullPath.endsWith('.toml'))) {
+        return res.status(400).send('Can only save markdown and TOML files');
+      }
+
+      const { content } = req.body;
+
+      // Optional If-Match contract: when the editor was rendered, it embedded
+      // a SHA-256 of the on-disk content and sends it back as X-If-Match-Sha256
+      // on save. If the on-disk hash differs, refuse the write so we don't
+      // clobber a concurrent edit.
+      const ifMatch = req.get('X-If-Match-Sha256');
+      let currentContent = null;
+      try {
+        currentContent = await fs.readFile(fullPath, 'utf-8');
+      } catch {
+        // File vanished between stat() and readFile() — fall through; the
+        // CAS write below treats currentContent === null as "must not exist"
+        // and will conflict if the file is recreated under us.
+      }
+
+      if (ifMatch) {
+        const actualSha256 = currentContent === null
+          ? null
+          : crypto.createHash('sha256').update(currentContent).digest('hex');
+        if (actualSha256 !== ifMatch) {
+          return res.status(409).json({
+            success: false,
+            conflict: true,
+            message: 'File changed externally since you opened it.',
+            expectedSha256: ifMatch,
+            actualSha256,
+          });
+        }
+      }
+
+      // CAS guards the narrow window between the readFile above and the
+      // rename below, even when If-Match wasn't supplied.
+      const { conflict } = await writeFileAtomicCASAsync(fullPath, content, currentContent);
+      if (conflict) {
+        return res.status(409).json({
+          success: false,
+          conflict: true,
+          message: 'File changed externally during save.',
+        });
+      }
+
+      if (postWriteHook) {
+        try { await postWriteHook(fullPath); } catch { /* ignore */ }
+      }
+      res.json({ success: true, message: 'File saved successfully' });
+    } catch (error) {
+      console.error('Error saving file:', error);
+      res.status(500).json({ success: false, message: 'Failed to save file' });
+    }
+  };
+}

--- a/src/save-route.js
+++ b/src/save-route.js
@@ -13,7 +13,7 @@ import { writeFileAtomicCASAsync } from './fs-atomic.js';
 /**
  * @param {object} opts
  * @param {string} opts.vaultPath - Absolute path to the vault root.
- * @param {(filePath: string) => Promise<{ok: true, file: string} | {ok: false, reason: string}>} [opts.postWriteHook]
+ * @param {(filePath: string) => (void | Promise<void>)} [opts.postWriteHook]
  *   Optional hook fired after a successful write — used by the live server to
  *   log; tests can pass a recorder.
  */
@@ -25,17 +25,22 @@ export function createSaveHandler({ vaultPath, postWriteHook } = {}) {
       const urlPath = Array.isArray(req.params.path)
         ? req.params.path.join('/')
         : req.params.path;
-      let fullPath = path.join(vaultPath, urlPath);
+      // Resolve the full path and ensure it is contained within the vault.
+      // Using path.resolve (rather than path.join) collapses any `..` segments
+      // before the check, and requiring the sep suffix prevents the
+      // vault-prefix sibling bypass (e.g. /tmp/vault2 vs /tmp/vault).
+      let fullPath = path.resolve(vaultPath, urlPath);
+      const vaultRoot = vaultPath.endsWith(path.sep) ? vaultPath : vaultPath + path.sep;
 
       // Security: prevent directory traversal
-      if (!fullPath.startsWith(vaultPath)) {
+      if (fullPath !== vaultPath && !fullPath.startsWith(vaultRoot)) {
         return res.status(403).send('Access denied');
       }
 
       // If path has no extension, try adding .md (Obsidian-style URLs)
       if (!path.extname(urlPath)) {
         fullPath = fullPath + '.md';
-        if (!fullPath.startsWith(vaultPath)) {
+        if (fullPath !== vaultPath && !fullPath.startsWith(vaultRoot)) {
           return res.status(403).send('Access denied');
         }
       }

--- a/src/save-route.js
+++ b/src/save-route.js
@@ -61,10 +61,8 @@ export function createSaveHandler({ vaultPath, postWriteHook } = {}) {
         // and will conflict if the file is recreated under us.
       }
 
-      if (ifMatch) {
-        const actualSha256 = currentContent === null
-          ? null
-          : crypto.createHash('sha256').update(currentContent).digest('hex');
+      if (ifMatch && currentContent !== null) {
+        const actualSha256 = crypto.createHash('sha256').update(currentContent).digest('hex');
         if (actualSha256 !== ifMatch) {
           return res.status(409).json({
             success: false,

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -42,6 +42,7 @@ import {
   buildMessages,
 } from './ai-chat/index.js';
 import { getNavbar, getThemeBootstrapScript, getThemeToggleButtonHtml } from './web/navbar.js';
+import { createSaveHandler } from './save-route.js';
 
 // Configure marked extensions
 marked.use(gfmHeadingId());
@@ -1791,6 +1792,12 @@ Contents:
 async function renderEditor(filePath, urlPath) {
   const content = await fs.readFile(filePath, 'utf-8');
   const fileName = path.basename(urlPath);
+
+  // SHA-256 of the content at render time. The editor sends this back
+  // on save as X-If-Match-Sha256 so the /save handler can refuse the
+  // write if the file changed under us (concurrent edit, sync-in from
+  // another box, etc.). See issue #293.
+  const originalSha256 = crypto.createHash('sha256').update(content).digest('hex');
   
   // Build breadcrumb
   const breadcrumbParts = urlPath ? urlPath.split('/').filter(Boolean) : [];
@@ -1856,36 +1863,63 @@ async function renderEditor(filePath, urlPath) {
       ${pageScripts}
 
       <script>
+        // SHA-256 of the file content as it was read at render time. Sent on
+        // save as X-If-Match-Sha256 so the server can refuse a stale-baseline
+        // write (see #293). If this is ever updated mid-session (eg. after a
+        // successful save), reassign window.__editorOriginalSha256 to the
+        // hash of the just-saved content.
+        window.__editorOriginalSha256 = ${JSON.stringify(originalSha256)};
+
+        async function sha256Hex(text) {
+          const bytes = new TextEncoder().encode(text);
+          const digest = await crypto.subtle.digest('SHA-256', bytes);
+          return Array.from(new Uint8Array(digest))
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('');
+        }
+
         // Page-specific functions (performSearch is in common.js)
-        function saveFile() {
+        async function saveFile() {
           const content = document.getElementById('editor').value;
           const saveStatus = document.getElementById('save-status');
 
           saveStatus.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Saving...';
           saveStatus.className = 'text-primary small me-3';
 
-          fetch('/save/${urlPath}', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ content: content })
-          })
-          .then(response => {
-            if (response.ok) {
-              saveStatus.innerHTML = '<i class="fas fa-check me-1"></i>Saved successfully!';
-              saveStatus.className = 'text-success small me-3';
-              setTimeout(() => {
-                saveStatus.innerHTML = '';
-              }, 3000);
-            } else {
+          try {
+            const response = await fetch('/save/${urlPath}', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-If-Match-Sha256': window.__editorOriginalSha256 || '',
+              },
+              body: JSON.stringify({ content: content })
+            });
+
+            if (response.status === 409) {
+              const body = await response.json().catch(() => ({}));
+              saveStatus.innerHTML = '<i class="fas fa-triangle-exclamation me-1"></i>This file changed externally since you opened it. Copy your edits, then reload to see the latest version.';
+              saveStatus.className = 'text-warning small me-3';
+              console.warn('Save conflict:', body);
+              return;
+            }
+
+            if (!response.ok) {
               throw new Error('Save failed');
             }
-          })
-          .catch(error => {
+
+            // Successful save: the just-saved content is now the on-disk
+            // baseline, so refresh the If-Match hash for the next save.
+            window.__editorOriginalSha256 = await sha256Hex(content);
+            saveStatus.innerHTML = '<i class="fas fa-check me-1"></i>Saved successfully!';
+            saveStatus.className = 'text-success small me-3';
+            setTimeout(() => {
+              saveStatus.innerHTML = '';
+            }, 3000);
+          } catch (error) {
             saveStatus.innerHTML = '<i class="fas fa-exclamation-triangle me-1"></i>Save failed!';
             saveStatus.className = 'text-danger small me-3';
-          });
+          }
         }
 
         // Auto-save on Ctrl+S / Cmd+S
@@ -7190,44 +7224,14 @@ app.post('/task/edit', authMiddleware, async (req, res) => {
   }
 });
 
-app.post('/save/*path', authMiddleware, async (req, res) => {
-  try {
-    const urlPath = Array.isArray(req.params.path) ? req.params.path.join('/') : req.params.path; // Get the wildcard path
-    let fullPath = path.join(VAULT_PATH, urlPath);
-
-    // Security: prevent directory traversal
-    if (!fullPath.startsWith(VAULT_PATH)) {
-      return res.status(403).send('Access denied');
-    }
-
-    // If path has no extension, try adding .md (Obsidian-style URLs)
-    if (!path.extname(urlPath)) {
-      fullPath = fullPath + '.md';
-      if (!fullPath.startsWith(VAULT_PATH)) {
-        return res.status(403).send('Access denied');
-      }
-    }
-
-    // Check if file exists and is a markdown or TOML file
-    const stats = await fs.stat(fullPath);
-    if (!stats.isFile() || (!fullPath.endsWith('.md') && !fullPath.endsWith('.toml'))) {
-      return res.status(400).send('Can only save markdown and TOML files');
-    }
-    
-    // Write the content. The save endpoint doesn't carry an expected-content
-    // basis from the client, so atomic-only — readers can't observe a torn
-    // file mid-write, but a true write-write race still favors the last
-    // writer. Threading CAS through would require a client-side contract change.
-    const { content } = req.body;
-    await writeFileAtomicAsync(fullPath, content);
-
-    console.log(`File saved: ${fullPath}`);
-    res.json({ success: true, message: 'File saved successfully' });
-  } catch (error) {
-    console.error('Error saving file:', error);
-    res.status(500).json({ success: false, message: 'Failed to save file' });
-  }
-});
+app.post(
+  '/save/*path',
+  authMiddleware,
+  createSaveHandler({
+    vaultPath: VAULT_PATH,
+    postWriteHook: (filePath) => { console.log(`File saved: ${filePath}`); },
+  })
+);
 
 // Start time tracking timer
 app.post('/api/track/start', authMiddleware, express.json(), async (req, res) => {

--- a/test/save-route.test.js
+++ b/test/save-route.test.js
@@ -15,6 +15,7 @@ import fs from 'fs/promises';
 import fsSync from 'fs';
 import os from 'os';
 import path from 'path';
+import { jest } from '@jest/globals';
 
 import { createSaveHandler } from '../src/save-route.js';
 
@@ -110,6 +111,33 @@ describe('createSaveHandler (issue #293)', () => {
       expect(res.status).toBe(200);
       expect(await fs.readFile(filePath, 'utf-8')).toBe('no-header write\n');
     });
+  });
+
+  test('If-Match save still succeeds when file is deleted between stat() and readFile()', async () => {
+    const handler = createSaveHandler({ vaultPath });
+    const ifMatch = sha256('original baseline\n');
+    const readSpy = jest.spyOn(fs, 'readFile').mockImplementationOnce(async () => {
+      await fs.unlink(filePath);
+      throw new Error('simulated ENOENT between stat and read');
+    });
+
+    try {
+      await withServer(handler, async (base) => {
+        const res = await fetch(`${base}/save/plan.md`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-If-Match-Sha256': ifMatch,
+          },
+          body: JSON.stringify({ content: 'recreated after delete\n' }),
+        });
+
+        expect(res.status).toBe(200);
+        expect(await fs.readFile(filePath, 'utf-8')).toBe('recreated after delete\n');
+      });
+    } finally {
+      readSpy.mockRestore();
+    }
   });
 
   test('directory traversal is refused', async () => {

--- a/test/save-route.test.js
+++ b/test/save-route.test.js
@@ -154,6 +154,36 @@ describe('createSaveHandler (issue #293)', () => {
     });
   });
 
+  test('vault-prefix sibling bypass is refused', async () => {
+    // vaultPath is e.g. /tmp/save-route-XXXXXX; this constructs a sibling
+    // directory that shares the same prefix (e.g. /tmp/save-route-XXXXXXsibling).
+    // A naive startsWith(vaultPath) check would allow escaping into it.
+    const siblingPath = vaultPath + 'sibling';
+    fsSync.mkdirSync(siblingPath, { recursive: true });
+    fsSync.writeFileSync(path.join(siblingPath, 'evil.md'), 'original\n');
+
+    const handler = createSaveHandler({ vaultPath });
+
+    try {
+      await withServer(handler, async (base) => {
+        // Craft a URL that resolves to siblingPath/evil.md via ../sibling/evil.md
+        const vaultBasename = path.basename(vaultPath);
+        const escapedUrl = `../${vaultBasename}sibling/evil.md`;
+        const res = await fetch(`${base}/save/${encodeURIComponent(escapedUrl)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: 'should not land\n' }),
+        });
+
+        expect(res.status).toBe(403);
+        // Confirm the sibling file was not overwritten
+        expect(fsSync.readFileSync(path.join(siblingPath, 'evil.md'), 'utf-8')).toBe('original\n');
+      });
+    } finally {
+      fsSync.rmSync(siblingPath, { recursive: true, force: true });
+    }
+  });
+
   test('non-markdown/toml file rejected', async () => {
     fsSync.writeFileSync(path.join(vaultPath, 'notes.txt'), 'plain text\n');
     const handler = createSaveHandler({ vaultPath });

--- a/test/save-route.test.js
+++ b/test/save-route.test.js
@@ -1,0 +1,158 @@
+/**
+ * Tests for the /save handler factory.
+ *
+ * Covers the If-Match/CAS contract added by #293:
+ * - matching X-If-Match-Sha256 → 200, file replaced
+ * - mismatched X-If-Match-Sha256 → 409 with detail body, file untouched
+ * - no header at all → 200 (backward compatible) and still CAS-protected
+ *   against a write that lands between read and rename
+ * - directory traversal still refused
+ */
+
+import crypto from 'crypto';
+import express from 'express';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { createSaveHandler } from '../src/save-route.js';
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+async function withServer(handler, run) {
+  const app = express();
+  app.use(express.json());
+  app.post('/save/*path', handler);
+
+  const server = await new Promise((resolve, reject) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    s.once('error', reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+describe('createSaveHandler (issue #293)', () => {
+  let vaultPath;
+  let filePath;
+
+  beforeEach(() => {
+    vaultPath = fsSync.mkdtempSync(path.join(os.tmpdir(), 'save-route-'));
+    filePath = path.join(vaultPath, 'plan.md');
+    fsSync.writeFileSync(filePath, 'original baseline\n');
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(vaultPath, { recursive: true, force: true });
+  });
+
+  test('matching X-If-Match-Sha256 → 200, content replaced', async () => {
+    const handler = createSaveHandler({ vaultPath });
+    const ifMatch = sha256('original baseline\n');
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/plan.md`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-If-Match-Sha256': ifMatch,
+        },
+        body: JSON.stringify({ content: 'new content\n' }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('new content\n');
+    });
+  });
+
+  test('mismatched X-If-Match-Sha256 → 409, file untouched, diagnostics returned', async () => {
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/plan.md`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-If-Match-Sha256': 'cafebabe-stale-hash',
+        },
+        body: JSON.stringify({ content: 'should not land\n' }),
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.conflict).toBe(true);
+      expect(body.expectedSha256).toBe('cafebabe-stale-hash');
+      expect(body.actualSha256).toBe(sha256('original baseline\n'));
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('original baseline\n');
+    });
+  });
+
+  test('no If-Match header → 200 (backward-compatible), file replaced', async () => {
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/plan.md`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'no-header write\n' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('no-header write\n');
+    });
+  });
+
+  test('directory traversal is refused', async () => {
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/..%2Fescape.md`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'malicious\n' }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  test('non-markdown/toml file rejected', async () => {
+    fsSync.writeFileSync(path.join(vaultPath, 'notes.txt'), 'plain text\n');
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/notes.txt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'should be rejected\n' }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  test('extensionless URL gets .md appended (Obsidian-style)', async () => {
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save/plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'obsidian-style\n' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('obsidian-style\n');
+    });
+  });
+});


### PR DESCRIPTION
The `/save` route's traversal check used `startsWith(vaultPath)` which is bypassable via a sibling directory sharing the vault's prefix (e.g. `/tmp/vault2/…` passes against `/tmp/vault`). The `postWriteHook` JSDoc claimed a structured return type that no real caller or test ever satisfies.

## Changes

- **`src/save-route.js` — traversal guard**: replace `path.join` + `startsWith(vaultPath)` with `path.resolve` (collapses `..` before any check) and validate against `vaultPath + path.sep` suffix so prefix-siblings are rejected. Applied to both the initial check and the Obsidian-style `.md` extension path.

  ```js
  // before — bypassable
  let fullPath = path.join(vaultPath, urlPath);
  if (!fullPath.startsWith(vaultPath)) { … }

  // after — safe
  let fullPath = path.resolve(vaultPath, urlPath);
  const vaultRoot = vaultPath.endsWith(path.sep) ? vaultPath : vaultPath + path.sep;
  if (fullPath !== vaultPath && !fullPath.startsWith(vaultRoot)) { … }
  ```

- **`src/save-route.js` — JSDoc**: `postWriteHook` return type corrected from `Promise<{ok:true,…}|{ok:false,…}>` to `void | Promise<void>`.

- **`test/save-route.test.js`**: adds `'vault-prefix sibling bypass is refused'` — creates `vaultPath + 'sibling'`, attempts to write into it via a `../…sibling/evil.md` traversal URL, asserts 403 and that the sibling file is untouched.