### PR TITLE
fix(vault): close three remaining unsafe write paths

### DIFF
--- a/src/ai-chat/tools.js
+++ b/src/ai-chat/tools.js
@@ -279,20 +279,22 @@ export function createCreateFileTool() {
           return { success: false, error: 'Cannot create files outside the vault' };
         }
 
-        // Check if file already exists
-        try {
-          await fs.access(resolvedPath);
-          return { success: false, error: `File already exists: ${normalizedPath}. Use edit_file to modify existing files.` };
-        } catch {
-          // File doesn't exist, good to proceed
-        }
-
         // Create parent directories if they don't exist
         const parentDir = path.dirname(resolvedPath);
         await fs.mkdir(parentDir, { recursive: true });
 
-        // Write the file
-        await fs.writeFile(resolvedPath, content, 'utf-8');
+        // Compare-and-swap write expecting the file NOT to exist (baseline
+        // = null). Closes the TOCTOU window between a separate fs.access
+        // existence check and the write — if the file gets created in
+        // between, the CAS fails and we report a useful error instead of
+        // silently overwriting somebody else's content.
+        const { conflict } = await writeFileAtomicCASAsync(resolvedPath, content, null);
+        if (conflict) {
+          return {
+            success: false,
+            error: `File already exists: ${normalizedPath}. Use edit_file to modify existing files.`,
+          };
+        }
 
         return {
           success: true,

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -3175,9 +3175,15 @@ class DataviewAPI {
     return {
       vault: {
         adapter: {
+          // Atomic write via temp-file + rename. We can't do CAS here because
+          // Obsidian's adapter.write() contract is a blind overwrite and
+          // vault scripts (eg. time-tracking-widget.js) pass through their
+          // own read-modify-write state — they'd need to thread the baseline
+          // to us before we could check it. The atomic-rename at least keeps
+          // readers from observing a torn file mid-write.
           async write(filePath, content) {
             const fullPath = path.join(self.vaultPath, filePath);
-            await fs.writeFile(fullPath, content, 'utf-8');
+            await writeFileAtomicAsync(fullPath, content);
           }
         }
       }
@@ -6144,18 +6150,34 @@ app.post('/ai-edit/*path', authMiddleware, async (req, res) => {
   try {
     const urlPath = Array.isArray(req.params.path) ? req.params.path.join('/') : req.params.path; // Get the wildcard path
     const fullPath = path.join(VAULT_PATH, urlPath);
-    const { content } = req.body;
-    
+    const { content, expectedContent } = req.body;
+
     // Security check
     if (!fullPath.startsWith(VAULT_PATH)) {
       return res.status(403).json({ error: 'Access denied' });
     }
-    
-    // Write the file. AI-edit endpoints don't carry an expected-content
-    // basis from the client, so we use atomic-only writes (no CAS): readers
-    // can't observe a torn file mid-write, but a true write-write race
-    // between two AI-edit requests still favors the last writer.
-    await writeFileAtomicAsync(fullPath, content);
+
+    // Compare-and-swap against the bytes the caller saw. If the client
+    // supplied `expectedContent` (the version it last read), use that as
+    // the baseline so we refuse to overwrite a newer concurrent edit.
+    // Otherwise fall back to a snapshot taken just before the write —
+    // narrower window than atomic-only but still catches simultaneous
+    // writers that arrive after our read.
+    let baseline = expectedContent;
+    if (baseline === undefined) {
+      try {
+        baseline = await fs.readFile(fullPath, 'utf-8');
+      } catch (err) {
+        baseline = err && err.code === 'ENOENT' ? null : '';
+      }
+    }
+
+    const { conflict } = await writeFileAtomicCASAsync(fullPath, content, baseline);
+    if (conflict) {
+      return res.status(409).json({
+        error: 'File changed since it was read. Refresh and retry.',
+      });
+    }
 
     res.json({ success: true });
   } catch (error) {

--- a/test/ai-chat-create-file-tool.test.js
+++ b/test/ai-chat-create-file-tool.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for the create_file AI tool's compare-and-swap behavior.
+ *
+ * Regression coverage for the umbrella vault-damage fix (#297). The tool
+ * previously did `fs.access` then `fs.writeFile`, a TOCTOU window where a
+ * separate writer could create the file in between and silently get
+ * clobbered. The fix uses writeFileAtomicCASAsync with a null baseline
+ * (meaning "expect no file") so a concurrent creation is reported as a
+ * conflict instead.
+ */
+
+import { jest } from '@jest/globals';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+let tempVault;
+jest.unstable_mockModule('../src/config.js', () => ({
+  getAbsoluteVaultPath: () => tempVault,
+  getFullConfig: () => ({}),
+}));
+
+const { createCreateFileTool } = await import('../src/ai-chat/tools.js');
+
+describe('create_file tool CAS behavior', () => {
+  beforeEach(() => {
+    tempVault = fsSync.mkdtempSync(path.join(os.tmpdir(), 'create-file-cas-'));
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(tempVault, { recursive: true, force: true });
+  });
+
+  test('happy path: creates a new file under a new directory', async () => {
+    const result = await createCreateFileTool().execute({
+      filePath: 'projects/attachments/letter.html',
+      content: '<p>hello</p>',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe('projects/attachments/letter.html');
+    const onDisk = await fs.readFile(
+      path.join(tempVault, 'projects/attachments/letter.html'),
+      'utf-8',
+    );
+    expect(onDisk).toBe('<p>hello</p>');
+  });
+
+  test('refuses to overwrite an existing file', async () => {
+    const existing = path.join(tempVault, 'notes.md');
+    await fs.writeFile(existing, 'pre-existing content\n');
+
+    const result = await createCreateFileTool().execute({
+      filePath: 'notes.md',
+      content: 'new content\n',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+    // Original content untouched.
+    expect(await fs.readFile(existing, 'utf-8')).toBe('pre-existing content\n');
+  });
+
+  test('rejects paths that escape the vault', async () => {
+    const result = await createCreateFileTool().execute({
+      filePath: '../outside.md',
+      content: 'malicious\n',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/outside the vault/i);
+  });
+
+  test('strips a leading slash on the requested path', async () => {
+    const result = await createCreateFileTool().execute({
+      filePath: '/inbox/new.md',
+      content: 'body\n',
+    });
+
+    expect(result.success).toBe(true);
+    expect(
+      await fs.readFile(path.join(tempVault, 'inbox/new.md'), 'utf-8'),
+    ).toBe('body\n');
+  });
+});


### PR DESCRIPTION
## Summary

The earlier CAS work (#270, #274, #285, #290, #292) closed most file-clobber paths in the vault, but **three** are still raw or atomic-only when they should be compare-and-swap. Each one is a place where a stale snapshot or a TOCTOU window can silently overwrite a concurrent writer's bytes — likely contributors to the daily plan-file gutting and \`tasks-1.md\` damage we keep seeing.

### What changes

**1. \`src/web-server.js\` — \`/ai-edit/*path\` endpoint**

Was: \`writeFileAtomicAsync(fullPath, content)\` (atomic, but no CAS).

Two concurrent ai-edit requests would race last-writer-wins, and an AI agent generating a whole-file content from a stale view could silently overwrite newer disk bytes.

Now reads the on-disk content as a CAS baseline (or accepts an optional \`expectedContent\` from the client) and calls \`writeFileAtomicCASAsync\`. Returns 409 on conflict.

**2. \`src/ai-chat/tools.js\` — \`create_file\` tool**

Was: \`fs.access(resolvedPath)\` then \`fs.writeFile\`. Classic TOCTOU — a concurrent create between the access-check and the write got silently clobbered.

Now uses \`writeFileAtomicCASAsync(resolvedPath, content, null)\` with \`null\` baseline, which is the explicit "expect file does not exist" contract. A concurrent create produces a clean conflict instead.

**3. \`src/web-server.js\` — Obsidian shim \`app.vault.adapter.write\`**

Was: raw \`fs.writeFile\`. Used by vault scripts (eg. \`time-tracking-widget.js\`) for whole-file overwrites. We can't add CAS here without breaking the shim's contract — callers pass through their own read-modify-write state, so the baseline isn't in scope at the shim layer. Switching to \`writeFileAtomicAsync\` at least prevents torn reads mid-write.

### What this does NOT fix

The shim still allows a vault script's stale read to clobber a newer write — closing that requires threading a baseline through every vault-script writer call site. Separate, larger change.

### Tests

- \`test/ai-chat-create-file-tool.test.js\` (new): happy path, existing-file refusal, vault traversal protection, leading-slash normalization (4 cases).
- Full suite: 673/673 pass across 34 suites.

Fixes #297

## Test plan

- [x] \`npm test\` — full suite, 673 passed
- [x] \`npm test -- test/ai-chat-create-file-tool.test.js\` — 4 new cases pass
- [ ] Manual: hit \`/ai-edit\` twice concurrently from two browser sessions, confirm the second returns 409 instead of silently winning
- [ ] Manual: after deploy, observe \`git log plans/\` in the vault — gutting commits should stop appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)