### PR TITLE
Cache "Gathering context" startup step (#303)

### DIFF
--- a/bin/plugins
+++ b/bin/plugins
@@ -26,6 +26,7 @@ import { exportUpcomingEvents } from '../src/export-calendar-events.js';
 import { getAbsoluteVaultPath, getConfigPath } from '../src/config.js';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import { getDatabase } from '../src/database-service.js';
+import { getDataContextCached } from '../src/context-cache.js';
 import { ensureHealthyDatabase, createFreshDatabase } from '../src/db-health.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -553,6 +554,13 @@ displaying results. Use 'bin/plugins sync' to force an immediate refresh.
       const db = getDatabase();
       const context = { db, vaultPath };
       await runSyncOperation(context, pluginName, sourceName, options);
+      // Warm the context cache so the next interactive startup is an instant hit.
+      // Best-effort: sync must never fail because of cache warming.
+      try {
+        await getDataContextCached({ db, projectRoot: PROJECT_ROOT, bypass: true });
+      } catch {
+        // Ignore cache-warming failures
+      }
       return; // Success - exit the retry loop
     } catch (error) {
       if (isDatabaseCorruptionError(error) && retryCount < maxRetries) {

--- a/bin/today
+++ b/bin/today
@@ -232,11 +232,12 @@ async function main() {
   const { execSync, spawnSync } = await import('child_process');
   const readline = await import('readline');
 
-  const { getTimezone, getFullConfig, configExists, getAbsoluteVaultPath, getFocusPresets, getFocusPreset, getConfigPath } = await import('../src/config.js');
+  const { getTimezone, getFullConfig, configExists, getAbsoluteVaultPath, getFocusPresets, getFocusPreset } = await import('../src/config.js');
   const { getInteractiveModel, getInteractiveProviderName, checkProviderBinarySync } = await import('../src/ai-provider.js');
-  const { getAIInstructionsByType, getPluginSources, checkPluginVaultFileChanges } = await import('../src/plugin-loader.js');
+  const { checkPluginVaultFileChanges } = await import('../src/plugin-loader.js');
   const { program } = await import('commander');
-  const { getPluginTypes, getAIMetadata, generateAIContextBlock, schemas } = await import('../src/plugin-schemas.js');
+  const { getDatabase } = await import('../src/database-service.js');
+  const { getDataContextCached } = await import('../src/context-cache.js');
   const { ensureHealthyDatabase } = await import('../src/db-health.js');
   const { getCurrentTime, formatFullDateTime } = await import('../src/date-utils.js');
   const { runConfigure } = await import('../src/configure-ui.js');
@@ -311,220 +312,22 @@ async function main() {
     }
   }
 
-  async function getDataContext() {
-    if (process.env.SKIP_CONTEXT === 'true') {
-      return `# Data Sources
-(Context gathering skipped for testing)`;
-    }
-
-    try {
-      const pluginTypes = getPluginTypes();
-      const instructionsByType = await getAIInstructionsByType();
-      const sections = [];
-
-      for (const pluginType of pluginTypes) {
-        const ai = getAIMetadata(pluginType);
-        if (!ai) continue;
-
-        if (pluginType === 'context') {
-          const contextData = await getContextPluginsData(instructionsByType.get('context'));
-          if (contextData) {
-            sections.push(contextData);
-          }
-          continue;
-        }
-
-        const typeData = instructionsByType.get(pluginType);
-        if (!typeData || typeData.sources.length === 0) continue;
-
-        let currentData = '';
-        try {
-          if (process.env.TODAY_QUIET !== '1') console.log(`  ⏳ ${ai.name || pluginType}...`);
-          currentData = execSync(ai.defaultCommand + ' 2>/dev/null', {
-            encoding: 'utf8',
-            timeout: 10000,
-            env: { ...process.env, CONTEXT_ONLY: 'true' }
-          });
-          currentData = currentData.split('\n')
-            .filter(line => !line.includes('[dotenvx'))
-            .join('\n');
-        } catch {
-          currentData = '(No data available)';
-        }
-
-        const block = generateAIContextBlock(pluginType, {
-          userInstructions: typeData.instructions,
-          currentData
-        });
-
-        if (block) {
-          sections.push(block);
-        }
-      }
-
-      if (sections.length === 0) {
-        return `# Data Sources
-
-**No plugins are currently enabled.**
-
-Today works best when connected to your data sources (calendars, tasks, notes, etc.).
-Run \`bin/today configure\` and select "Plugins" to enable data sources.
-
-Available plugin types include:
-- Calendars (Google Calendar, public calendars)
-- Tasks and projects (GitHub, markdown files)
-- Notes and diary (Day One, markdown files)
-- Time tracking, habits, health metrics
-- Weather and other context
-
-The more data sources you enable, the more helpful Today can be.
-`;
-      }
-
-      const intro = `# Data Sources
-
-The following data is synced from external sources via the plugin system.
-Each section shows current data and instructions for querying more.
-
-- Run \`bin/plugins list\` to see available plugins
-- Run \`bin/plugins sync\` to refresh data from all sources
-- Run \`bin/plugins sync <plugin-name>\` to sync a specific plugin
-
-`;
-
-      return intro + sections.join('\n\n---\n\n');
-    } catch (error) {
-      return '';
-    }
-  }
-
-  async function getDataContextForDate(targetDate) {
-    const sections = [];
-    const pluginTypes = getPluginTypes();
-    const historicalTypes = ['time-logs', 'diary', 'events', 'tasks', 'habits'];
-
-    for (const pluginType of pluginTypes) {
-      if (!historicalTypes.includes(pluginType)) continue;
-
-      const schema = schemas[pluginType];
-      if (!schema || !schema.ai?.dateCommand) continue;
-
-      const command = schema.ai.dateCommand.replace('$DATE', targetDate);
-
-      try {
-        const output = execSync(command, {
-          cwd: projectRoot,
-          encoding: 'utf8',
-          timeout: 30000,
-          stdio: ['pipe', 'pipe', 'pipe']
-        });
-
-        const cleanOutput = output.split('\n')
-          .filter(line => !line.includes('[dotenvx'))
-          .join('\n')
-          .trim();
-
-        if (!cleanOutput || cleanOutput.includes('No ')) continue;
-
-        const block = generateAIContextBlock(pluginType, {
-          userInstructions: [],
-          currentData: cleanOutput,
-          commandUsed: command
-        });
-
-        if (block) {
-          sections.push(block);
-        }
-      } catch {
-        // Command failed - skip this type
-      }
-    }
-
-    if (sections.length === 0) {
-      return `# Data Sources\n(No data found for ${targetDate})`;
-    }
-
-    const intro = `# Data Sources for ${targetDate}
-
-The following data was retrieved for the specified date.
-
-`;
-
-    return intro + sections.join('\n\n---\n\n');
-  }
-
-  async function getContextPluginsData(typeData) {
-    if (!typeData || typeData.sources.length === 0) return null;
-
-    const lines = ['## Contextual Information', ''];
-
-    // Include user ai_instructions for context plugins
-    if (typeData.instructions && typeData.instructions.length > 0) {
-      lines.push('**Specific instructions from the user:**');
-      for (const { sourceId, text } of typeData.instructions) {
-        lines.push(`From ${sourceId}:`);
-        lines.push(`> ${text.replace(/\n/g, '\n> ')}`);
-        lines.push('');
-      }
-    }
-
-    for (const sourceId of typeData.sources) {
-      try {
-        const [pluginName, sourceName] = sourceId.split('/');
-        const pluginPath = path.join(projectRoot, 'plugins', pluginName);
-        const readScript = path.join(pluginPath, 'read.js');
-
-        if (!fs.existsSync(readScript)) continue;
-
-        const sources = getPluginSources(pluginName);
-        const sourceConfig = sources.find(s => s.sourceName === sourceName)?.config || {};
-
-        if (process.env.TODAY_QUIET !== '1') console.log(`  ⏳ ${pluginName}...`);
-
-        const output = execSync(`node "${readScript}"`, {
-          cwd: projectRoot,
-          encoding: 'utf8',
-          timeout: 30000,
-          env: {
-            ...process.env,
-            PROJECT_ROOT: projectRoot,
-            CONFIG_PATH: getConfigPath(),
-            PLUGIN_CONFIG: JSON.stringify(sourceConfig),
-            SOURCE_ID: sourceId,
-            CONTEXT_ONLY: 'true' // Skip expensive operations during context gathering
-          }
-        });
-
-        const data = JSON.parse(output);
-
-        if (data.context) {
-          lines.push(data.context);
-          lines.push('');
-        }
-      } catch {
-        // Silently continue if plugin fails
-      }
-    }
-
-    return lines.length > 2 ? lines.join('\n') : null;
-  }
-
-  async function runInteractiveSession(directRequest = null, nonInteractive = false, dryRun = false, targetDate = null, compact = false, quiet = false) {
+  async function runInteractiveSession(directRequest = null, nonInteractive = false, dryRun = false, targetDate = null, compact = false, quiet = false, refreshContext = false) {
     const log = quiet ? () => {} : console.log.bind(console);
     const timezone = getTimezone();
 
     const now = getCurrentTime(timezone);
     const currentTime = formatFullDateTime(now, timezone);
 
-    let dataContext;
-    if (targetDate) {
-      log(`📊 Gathering context for ${targetDate}...`);
-      dataContext = await getDataContextForDate(targetDate);
-    } else {
-      log('📊 Gathering context...');
-      dataContext = await getDataContext();
-    }
-    log('✅ Context ready\n');
+    log(targetDate ? `📊 Gathering context for ${targetDate}...` : '📊 Gathering context...');
+    const bypassCache = refreshContext || process.env.SKIP_CONTEXT_CACHE === '1';
+    const { content: dataContext, cached } = await getDataContextCached({
+      db: getDatabase(),
+      projectRoot,
+      targetDate,
+      bypass: bypassCache
+    });
+    log(cached ? '✅ Context ready (cached)\n' : '✅ Context ready\n');
     const config = getFullConfig();
 
     const profile = config.profile || {};
@@ -760,7 +563,7 @@ ${contextSection}`;
   }
 
   async function runSession(request, options) {
-    const { sync, nonInteractive, quiet, date: targetDate } = options;
+    const { sync, nonInteractive, quiet, date: targetDate, refreshContext } = options;
     const log = quiet ? () => {} : console.log.bind(console);
 
     if (request) {
@@ -782,7 +585,7 @@ ${contextSection}`;
       log('⚠️  Skipping sync (--no-sync flag provided)');
     }
 
-    await runInteractiveSession(request, nonInteractive, false, targetDate, false, quiet);
+    await runInteractiveSession(request, nonInteractive, false, targetDate, false, quiet, refreshContext);
   }
 
   // Helper to merge parent (global) options with command-specific options
@@ -809,6 +612,7 @@ ${contextSection}`;
     .option('--quiet', 'Suppress status output (for scripts)')
     .option('--skip-update-check', 'Skip checking for updates')
     .option('--date <date>', 'Target date (YYYY-MM-DD) for historical data')
+    .option('--refresh-context', 'Rebuild the context cache instead of reusing it')
     .option('--focus [name]', 'Use a focus preset from config (or list available)');
 
   // Helper to show focus preset selection menu

--- a/src/context-cache.js
+++ b/src/context-cache.js
@@ -67,6 +67,51 @@ function serializeInstructions(instructionsByType) {
   return out;
 }
 
+function stableSortObject(value) {
+  if (Array.isArray(value)) {
+    return value.map(stableSortObject);
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = stableSortObject(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Snapshot enabled source configs used by context gathering.
+ * Captures config-only changes that should invalidate cached context.
+ * @param {Map} instructionsByType
+ * @returns {Array}
+ */
+function serializeSourceConfigs(instructionsByType) {
+  const sourceIds = new Set();
+  for (const data of instructionsByType.values()) {
+    for (const sourceId of (data.sources || [])) {
+      sourceIds.add(sourceId);
+    }
+  }
+
+  const serialized = [];
+  for (const sourceId of sourceIds) {
+    const [pluginName, sourceName] = sourceId.split('/');
+    let config = null;
+    try {
+      const sources = getPluginSources(pluginName);
+      config = sources.find(s => s.sourceName === sourceName)?.config ?? null;
+    } catch {
+      config = null;
+    }
+    serialized.push([sourceId, stableSortObject(config)]);
+  }
+
+  serialized.sort((a, b) => a[0].localeCompare(b[0]));
+  return serialized;
+}
+
 /**
  * Compute the cache key for the current context. All inputs are cheap (a config
  * read plus one indexed query) — no plugin commands run.
@@ -83,6 +128,7 @@ export function computeContextCacheKey({ db, instructionsByType, dayKey, targetD
     targetDate: targetDate || null,
     dayKey,
     instructions: serializeInstructions(instructionsByType),
+    sourceConfigs: serializeSourceConfigs(instructionsByType),
     sync: getSyncSnapshot(db)
   };
   return crypto.createHash('sha256').update(JSON.stringify(fingerprint)).digest('hex');

--- a/src/context-cache.js
+++ b/src/context-cache.js
@@ -1,0 +1,388 @@
+// Context cache: caches the "Gathering context" step so it is only recomputed
+// when something has actually changed.
+//
+// During context gathering every plugin command runs with CONTEXT_ONLY=true,
+// which skips syncing (see ensureSyncForType in plugin-loader.js) and merely
+// reads the already-synced SQLite DB to format markdown. The gathered context
+// is therefore a pure function of:
+//   - the set of enabled plugin sources + their ai_instructions,
+//   - the synced DB data (freshness tracked per-source in sync_metadata), and
+//   - the current local day (output is time-relative).
+// We fingerprint those cheap inputs *before* running any plugin command and
+// skip the whole loop on a cache hit.
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { execSync } from 'child_process';
+
+import { getPluginTypes, getAIMetadata, generateAIContextBlock, schemas } from './plugin-schemas.js';
+import { getAIInstructionsByType, getPluginSources } from './plugin-loader.js';
+import { getConfigPath, getTimezone } from './config.js';
+import { getTodayDate } from './date-utils.js';
+
+// Bump when the gather logic below changes in a way that should invalidate
+// every existing cache entry across an upgrade.
+export const CONTEXT_CACHE_VERSION = 1;
+
+// How many cache rows to retain (one per distinct fingerprint: live + a few
+// historical-date lookups). Older rows are pruned on each write.
+const MAX_CACHE_ROWS = 5;
+
+/**
+ * Snapshot the per-source sync state. This is the change signal: any sync
+ * (manual or background cron) updates last_synced_at, which changes the key.
+ * @param {object} db
+ * @returns {Array<object>}
+ */
+function getSyncSnapshot(db) {
+  try {
+    return db.prepare(
+      'SELECT source, last_synced_at, entries_count FROM sync_metadata ORDER BY source'
+    ).all();
+  } catch {
+    // Table might not exist yet
+    return [];
+  }
+}
+
+/**
+ * Serialize an instructionsByType Map into a stable, comparable structure.
+ * Captures which sources are enabled and their user ai_instructions.
+ * @param {Map} instructionsByType
+ * @returns {Array}
+ */
+function serializeInstructions(instructionsByType) {
+  const out = [];
+  for (const [type, data] of instructionsByType.entries()) {
+    out.push([
+      type,
+      [...(data.sources || [])].sort(),
+      (data.instructions || [])
+        .map(i => [i.sourceId, i.text])
+        .sort((a, b) => a[0].localeCompare(b[0]))
+    ]);
+  }
+  out.sort((a, b) => a[0].localeCompare(b[0]));
+  return out;
+}
+
+/**
+ * Compute the cache key for the current context. All inputs are cheap (a config
+ * read plus one indexed query) — no plugin commands run.
+ * @param {object} params
+ * @param {object} params.db - Database instance
+ * @param {Map} params.instructionsByType - From getAIInstructionsByType()
+ * @param {string} params.dayKey - Local day, YYYY-MM-DD
+ * @param {string|null} [params.targetDate] - Historical date, if any
+ * @returns {string} sha256 hex digest
+ */
+export function computeContextCacheKey({ db, instructionsByType, dayKey, targetDate = null }) {
+  const fingerprint = {
+    version: CONTEXT_CACHE_VERSION,
+    targetDate: targetDate || null,
+    dayKey,
+    instructions: serializeInstructions(instructionsByType),
+    sync: getSyncSnapshot(db)
+  };
+  return crypto.createHash('sha256').update(JSON.stringify(fingerprint)).digest('hex');
+}
+
+/**
+ * Look up cached content by key.
+ * @returns {string|null}
+ */
+export function getCachedContext(db, key) {
+  try {
+    const row = db.prepare('SELECT content FROM context_cache WHERE cache_key = ?').get(key);
+    return row ? row.content : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store cached content, then prune to the newest MAX_CACHE_ROWS entries.
+ */
+export function setCachedContext(db, key, content) {
+  try {
+    db.prepare(`
+      INSERT INTO context_cache (cache_key, content, created_at)
+      VALUES (?, ?, CURRENT_TIMESTAMP)
+      ON CONFLICT(cache_key) DO UPDATE SET content = excluded.content, created_at = CURRENT_TIMESTAMP
+    `).run(key, content);
+
+    db.prepare(`
+      DELETE FROM context_cache
+      WHERE cache_key NOT IN (
+        SELECT cache_key FROM context_cache ORDER BY created_at DESC, cache_key LIMIT ?
+      )
+    `).run(MAX_CACHE_ROWS);
+  } catch {
+    // Caching is best-effort; never break the caller.
+  }
+}
+
+/**
+ * Gather contextual data from the "context" plugin type (read.js sources).
+ * Moved verbatim from bin/today.
+ */
+async function getContextPluginsData(typeData, projectRoot) {
+  if (!typeData || typeData.sources.length === 0) return null;
+
+  const lines = ['## Contextual Information', ''];
+
+  // Include user ai_instructions for context plugins
+  if (typeData.instructions && typeData.instructions.length > 0) {
+    lines.push('**Specific instructions from the user:**');
+    for (const { sourceId, text } of typeData.instructions) {
+      lines.push(`From ${sourceId}:`);
+      lines.push(`> ${text.replace(/\n/g, '\n> ')}`);
+      lines.push('');
+    }
+  }
+
+  for (const sourceId of typeData.sources) {
+    try {
+      const [pluginName, sourceName] = sourceId.split('/');
+      const pluginPath = path.join(projectRoot, 'plugins', pluginName);
+      const readScript = path.join(pluginPath, 'read.js');
+
+      if (!fs.existsSync(readScript)) continue;
+
+      const sources = getPluginSources(pluginName);
+      const sourceConfig = sources.find(s => s.sourceName === sourceName)?.config || {};
+
+      if (process.env.TODAY_QUIET !== '1') console.log(`  ⏳ ${pluginName}...`);
+
+      const output = execSync(`node "${readScript}"`, {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        timeout: 30000,
+        env: {
+          ...process.env,
+          PROJECT_ROOT: projectRoot,
+          CONFIG_PATH: getConfigPath(),
+          PLUGIN_CONFIG: JSON.stringify(sourceConfig),
+          SOURCE_ID: sourceId,
+          CONTEXT_ONLY: 'true' // Skip expensive operations during context gathering
+        }
+      });
+
+      const data = JSON.parse(output);
+
+      if (data.context) {
+        lines.push(data.context);
+        lines.push('');
+      }
+    } catch {
+      // Silently continue if plugin fails
+    }
+  }
+
+  return lines.length > 2 ? lines.join('\n') : null;
+}
+
+/**
+ * Gather the current data context by running each enabled plugin's command in
+ * CONTEXT_ONLY mode. This is the expensive step the cache avoids repeating.
+ * Moved verbatim from bin/today's getDataContext().
+ */
+async function gatherCurrentDataContext(projectRoot) {
+  if (process.env.SKIP_CONTEXT === 'true') {
+    return `# Data Sources
+(Context gathering skipped for testing)`;
+  }
+
+  try {
+    const pluginTypes = getPluginTypes();
+    const instructionsByType = await getAIInstructionsByType();
+    const sections = [];
+
+    for (const pluginType of pluginTypes) {
+      const ai = getAIMetadata(pluginType);
+      if (!ai) continue;
+
+      if (pluginType === 'context') {
+        const contextData = await getContextPluginsData(instructionsByType.get('context'), projectRoot);
+        if (contextData) {
+          sections.push(contextData);
+        }
+        continue;
+      }
+
+      const typeData = instructionsByType.get(pluginType);
+      if (!typeData || typeData.sources.length === 0) continue;
+
+      let currentData = '';
+      try {
+        if (process.env.TODAY_QUIET !== '1') console.log(`  ⏳ ${ai.name || pluginType}...`);
+        currentData = execSync(ai.defaultCommand + ' 2>/dev/null', {
+          encoding: 'utf8',
+          timeout: 10000,
+          env: { ...process.env, CONTEXT_ONLY: 'true' }
+        });
+        currentData = currentData.split('\n')
+          .filter(line => !line.includes('[dotenvx'))
+          .join('\n');
+      } catch {
+        currentData = '(No data available)';
+      }
+
+      const block = generateAIContextBlock(pluginType, {
+        userInstructions: typeData.instructions,
+        currentData
+      });
+
+      if (block) {
+        sections.push(block);
+      }
+    }
+
+    if (sections.length === 0) {
+      return `# Data Sources
+
+**No plugins are currently enabled.**
+
+Today works best when connected to your data sources (calendars, tasks, notes, etc.).
+Run \`bin/today configure\` and select "Plugins" to enable data sources.
+
+Available plugin types include:
+- Calendars (Google Calendar, public calendars)
+- Tasks and projects (GitHub, markdown files)
+- Notes and diary (Day One, markdown files)
+- Time tracking, habits, health metrics
+- Weather and other context
+
+The more data sources you enable, the more helpful Today can be.
+`;
+    }
+
+    const intro = `# Data Sources
+
+The following data is synced from external sources via the plugin system.
+Each section shows current data and instructions for querying more.
+
+- Run \`bin/plugins list\` to see available plugins
+- Run \`bin/plugins sync\` to refresh data from all sources
+- Run \`bin/plugins sync <plugin-name>\` to sync a specific plugin
+
+`;
+
+    return intro + sections.join('\n\n---\n\n');
+  } catch (error) {
+    return '';
+  }
+}
+
+/**
+ * Gather data context for a specific historical date.
+ * Moved verbatim from bin/today's getDataContextForDate().
+ */
+async function gatherDataContextForDate(targetDate, projectRoot) {
+  const sections = [];
+  const pluginTypes = getPluginTypes();
+  const historicalTypes = ['time-logs', 'diary', 'events', 'tasks', 'habits'];
+
+  for (const pluginType of pluginTypes) {
+    if (!historicalTypes.includes(pluginType)) continue;
+
+    const schema = schemas[pluginType];
+    if (!schema || !schema.ai?.dateCommand) continue;
+
+    const command = schema.ai.dateCommand.replace('$DATE', targetDate);
+
+    try {
+      const output = execSync(command, {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        timeout: 30000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      const cleanOutput = output.split('\n')
+        .filter(line => !line.includes('[dotenvx'))
+        .join('\n')
+        .trim();
+
+      if (!cleanOutput || cleanOutput.includes('No ')) continue;
+
+      const block = generateAIContextBlock(pluginType, {
+        userInstructions: [],
+        currentData: cleanOutput,
+        commandUsed: command
+      });
+
+      if (block) {
+        sections.push(block);
+      }
+    } catch {
+      // Command failed - skip this type
+    }
+  }
+
+  if (sections.length === 0) {
+    return `# Data Sources\n(No data found for ${targetDate})`;
+  }
+
+  const intro = `# Data Sources for ${targetDate}
+
+The following data was retrieved for the specified date.
+
+`;
+
+  return intro + sections.join('\n\n---\n\n');
+}
+
+/**
+ * Gather data context (live or for a historical date) without consulting the
+ * cache. This is the expensive path.
+ * @param {object} params
+ * @param {string} params.projectRoot
+ * @param {string|null} [params.targetDate]
+ * @returns {Promise<string>}
+ */
+export async function gatherDataContext({ projectRoot, targetDate = null }) {
+  return targetDate
+    ? gatherDataContextForDate(targetDate, projectRoot)
+    : gatherCurrentDataContext(projectRoot);
+}
+
+/**
+ * Get data context, served from the context_cache when nothing relevant has
+ * changed. On a miss (or when bypassed) it gathers fresh, stores, and returns.
+ *
+ * @param {object} params
+ * @param {object} params.db - Database instance
+ * @param {string} params.projectRoot
+ * @param {string|null} [params.targetDate] - Historical date, if any
+ * @param {boolean} [params.bypass] - Force a fresh gather (still updates cache)
+ * @returns {Promise<{content: string, cached: boolean}>}
+ */
+export async function getDataContextCached({ db, projectRoot, targetDate = null, bypass = false }) {
+  // Preserve the SKIP_CONTEXT test short-circuit without touching the cache.
+  if (process.env.SKIP_CONTEXT === 'true' && !targetDate) {
+    return { content: await gatherDataContext({ projectRoot, targetDate }), cached: false };
+  }
+
+  let key = null;
+  try {
+    const dayKey = getTodayDate(getTimezone());
+    const instructionsByType = await getAIInstructionsByType();
+    key = computeContextCacheKey({ db, instructionsByType, dayKey, targetDate });
+  } catch {
+    // If we can't compute a key, fall back to always gathering fresh.
+    key = null;
+  }
+
+  if (key && !bypass) {
+    const hit = getCachedContext(db, key);
+    if (hit !== null) {
+      return { content: hit, cached: true };
+    }
+  }
+
+  const content = await gatherDataContext({ projectRoot, targetDate });
+  if (key) setCachedContext(db, key, content);
+  return { content, cached: false };
+}

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -75,6 +75,19 @@ const systemMigrations = [
       db.exec(`ALTER TABLE sync_metadata ADD COLUMN sync_locked_at DATETIME`);
       db.exec(`ALTER TABLE sync_metadata ADD COLUMN sync_locked_by TEXT`);
     }
+  },
+  {
+    version: 105,
+    description: 'Create context_cache table for caching gathered AI context',
+    fn: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS context_cache (
+          cache_key TEXT PRIMARY KEY,
+          content TEXT NOT NULL,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+    }
   }
 ];
 

--- a/test/context-cache.test.js
+++ b/test/context-cache.test.js
@@ -1,0 +1,200 @@
+import { jest } from '@jest/globals';
+
+// Mock config so timezone/config path are deterministic and don't read disk.
+jest.unstable_mockModule('../src/config.js', () => ({
+  getTimezone: jest.fn().mockReturnValue('America/New_York'),
+  getConfigPath: jest.fn().mockReturnValue('config.toml'),
+  getFullConfig: jest.fn().mockReturnValue({}),
+}));
+
+// Mock plugin-loader so context gathering sees no enabled plugins (no execSync).
+const getAIInstructionsByType = jest.fn();
+const getPluginSources = jest.fn().mockReturnValue([]);
+jest.unstable_mockModule('../src/plugin-loader.js', () => ({
+  getAIInstructionsByType,
+  getPluginSources,
+}));
+
+const Database = (await import('better-sqlite3')).default;
+const { MigrationManager } = await import('../src/migrations.js');
+const {
+  CONTEXT_CACHE_VERSION,
+  computeContextCacheKey,
+  getCachedContext,
+  setCachedContext,
+  getDataContextCached,
+} = await import('../src/context-cache.js');
+
+function makeInstructions(entries = []) {
+  // entries: [type, { sources, instructions }]
+  return new Map(entries);
+}
+
+describe('context cache', () => {
+  let db;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    await new MigrationManager(db, { verbose: false }).runMigrations();
+    getAIInstructionsByType.mockReset();
+    getAIInstructionsByType.mockResolvedValue(makeInstructions());
+    delete process.env.SKIP_CONTEXT;
+    delete process.env.SKIP_CONTEXT_CACHE;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('migration 105', () => {
+    test('creates the context_cache table', () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='context_cache'"
+      ).get();
+      expect(row).toBeDefined();
+      expect(row.name).toBe('context_cache');
+    });
+  });
+
+  describe('computeContextCacheKey', () => {
+    const base = () => ({
+      db,
+      instructionsByType: makeInstructions([['tasks', { sources: ['gh/today'], instructions: [] }]]),
+      dayKey: '2026-05-30',
+      targetDate: null,
+    });
+
+    test('is deterministic for identical inputs', () => {
+      expect(computeContextCacheKey(base())).toBe(computeContextCacheKey(base()));
+    });
+
+    test('is order-independent for sources and instructions', () => {
+      const a = computeContextCacheKey({
+        ...base(),
+        instructionsByType: makeInstructions([['tasks', { sources: ['a', 'b'], instructions: [] }]]),
+      });
+      const b = computeContextCacheKey({
+        ...base(),
+        instructionsByType: makeInstructions([['tasks', { sources: ['b', 'a'], instructions: [] }]]),
+      });
+      expect(a).toBe(b);
+    });
+
+    test('changes when the day changes', () => {
+      const a = computeContextCacheKey(base());
+      const b = computeContextCacheKey({ ...base(), dayKey: '2026-05-31' });
+      expect(a).not.toBe(b);
+    });
+
+    test('changes for a historical targetDate', () => {
+      const a = computeContextCacheKey(base());
+      const b = computeContextCacheKey({ ...base(), targetDate: '2026-01-01' });
+      expect(a).not.toBe(b);
+    });
+
+    test('changes when instructions change', () => {
+      const a = computeContextCacheKey(base());
+      const b = computeContextCacheKey({
+        ...base(),
+        instructionsByType: makeInstructions([
+          ['tasks', { sources: ['gh/today'], instructions: [{ sourceId: 'gh/today', text: 'be brief' }] }],
+        ]),
+      });
+      expect(a).not.toBe(b);
+    });
+
+    test('changes when sync_metadata changes (the core invalidation signal)', () => {
+      const before = computeContextCacheKey(base());
+      db.prepare(
+        'INSERT INTO sync_metadata (source, last_synced_at, entries_count) VALUES (?, ?, ?)'
+      ).run('gh/today', '2026-05-30 12:00:00', 3);
+      const after = computeContextCacheKey(base());
+      expect(before).not.toBe(after);
+
+      // A later sync time changes it again.
+      db.prepare('UPDATE sync_metadata SET last_synced_at = ? WHERE source = ?')
+        .run('2026-05-30 13:00:00', 'gh/today');
+      expect(computeContextCacheKey(base())).not.toBe(after);
+    });
+
+    test('folds in the cache version', () => {
+      expect(CONTEXT_CACHE_VERSION).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('getCachedContext / setCachedContext', () => {
+    test('round-trips content', () => {
+      expect(getCachedContext(db, 'k1')).toBeNull();
+      setCachedContext(db, 'k1', 'hello');
+      expect(getCachedContext(db, 'k1')).toBe('hello');
+    });
+
+    test('upserts content for an existing key', () => {
+      setCachedContext(db, 'k1', 'first');
+      setCachedContext(db, 'k1', 'second');
+      expect(getCachedContext(db, 'k1')).toBe('second');
+      expect(db.prepare('SELECT COUNT(*) AS n FROM context_cache').get().n).toBe(1);
+    });
+
+    test('prunes to a bounded number of rows', () => {
+      for (let i = 0; i < 9; i++) {
+        setCachedContext(db, `key-${i}`, `content-${i}`);
+      }
+      const n = db.prepare('SELECT COUNT(*) AS n FROM context_cache').get().n;
+      expect(n).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe('getDataContextCached', () => {
+    const call = (opts = {}) =>
+      getDataContextCached({ db, projectRoot: '/tmp', targetDate: null, ...opts });
+
+    test('gathers on a miss, then serves from cache on the next call', async () => {
+      const first = await call();
+      expect(first.cached).toBe(false);
+      expect(first.content).toContain('No plugins are currently enabled');
+      expect(db.prepare('SELECT COUNT(*) AS n FROM context_cache').get().n).toBe(1);
+
+      // Prove the second call serves the stored row rather than re-gathering:
+      // overwrite the cached content and confirm it comes back verbatim.
+      db.prepare('UPDATE context_cache SET content = ?').run('SENTINEL');
+      const second = await call();
+      expect(second.cached).toBe(true);
+      expect(second.content).toBe('SENTINEL');
+    });
+
+    test('bypass forces a fresh gather even when a cache row exists', async () => {
+      await call();
+      db.prepare('UPDATE context_cache SET content = ?').run('SENTINEL');
+
+      const fresh = await call({ bypass: true });
+      expect(fresh.cached).toBe(false);
+      expect(fresh.content).toContain('No plugins are currently enabled');
+      // The fresh gather refreshes the stored row.
+      expect(getCachedContext(db, db.prepare('SELECT cache_key FROM context_cache').get().cache_key))
+        .toContain('No plugins are currently enabled');
+    });
+
+    test('invalidates after a simulated sync', async () => {
+      await call();
+      db.prepare('UPDATE context_cache SET content = ?').run('SENTINEL');
+
+      // Simulate a sync: sync_metadata changes -> key changes -> miss.
+      db.prepare(
+        'INSERT INTO sync_metadata (source, last_synced_at, entries_count) VALUES (?, ?, ?)'
+      ).run('gh/today', '2026-05-30 12:00:00', 1);
+
+      const afterSync = await call();
+      expect(afterSync.cached).toBe(false);
+      expect(afterSync.content).not.toBe('SENTINEL');
+    });
+
+    test('honors the SKIP_CONTEXT test short-circuit without caching', async () => {
+      process.env.SKIP_CONTEXT = 'true';
+      const res = await call();
+      expect(res.cached).toBe(false);
+      expect(res.content).toContain('Context gathering skipped for testing');
+      expect(db.prepare('SELECT COUNT(*) AS n FROM context_cache').get().n).toBe(0);
+    });
+  });
+});

--- a/test/context-cache.test.js
+++ b/test/context-cache.test.js
@@ -37,6 +37,8 @@ describe('context cache', () => {
     db = new Database(':memory:');
     await new MigrationManager(db, { verbose: false }).runMigrations();
     getAIInstructionsByType.mockReset();
+    getPluginSources.mockReset();
+    getPluginSources.mockReturnValue([]);
     getAIInstructionsByType.mockResolvedValue(makeInstructions());
     delete process.env.SKIP_CONTEXT;
     delete process.env.SKIP_CONTEXT_CACHE;
@@ -100,6 +102,25 @@ describe('context cache', () => {
           ['tasks', { sources: ['gh/today'], instructions: [{ sourceId: 'gh/today', text: 'be brief' }] }],
         ]),
       });
+      expect(a).not.toBe(b);
+    });
+
+    test('changes when enabled source config changes', () => {
+      const params = {
+        ...base(),
+        instructionsByType: makeInstructions([['context', { sources: ['notes/main'], instructions: [] }]]),
+      };
+
+      getPluginSources.mockImplementation((pluginName) => pluginName === 'notes'
+        ? [{ sourceName: 'main', config: { folder: 'inbox' } }]
+        : []);
+      const a = computeContextCacheKey(params);
+
+      getPluginSources.mockImplementation((pluginName) => pluginName === 'notes'
+        ? [{ sourceName: 'main', config: { folder: 'archive' } }]
+        : []);
+      const b = computeContextCacheKey(params);
+
       expect(a).not.toBe(b);
     });
 


### PR DESCRIPTION
Closes #303.

## Problem

Every `bin/today` startup runs the "📊 Gathering context…" step, which shells out to **each** enabled plugin's command sequentially — each with a 10–30s timeout — before the interactive session can start. That loop is the slow startup the issue reports.

## Key insight

Those commands run with `CONTEXT_ONLY=true`, which makes them **skip syncing** (`ensureSyncForType` short-circuits) and merely *read* the already-synced SQLite DB to format markdown. So the gathered context is a pure function of:

- the enabled plugin sources + their `ai_instructions`,
- the synced DB data — whose freshness is already tracked per-source in `sync_metadata.last_synced_at`, and
- the current local day (output is time-relative).

That means it's safely cacheable, and `sync_metadata` gives a cheap change signal we can fingerprint **before** running any plugin command.

## Changes

- **Migration 105** adds a `context_cache` table.
- **`src/context-cache.js`** (new): fingerprint helpers + the gather logic (moved out of `bin/today`'s closure so it can be reused) + a `getDataContextCached()` orchestrator that serves from cache on a hit and rebuilds on a miss. The cache key folds in a cache version, the local day, `targetDate`, the enabled sources/instructions, and a `sync_metadata` snapshot — so **any sync, day rollover, or config change invalidates it**.
- **`bin/today`** now calls the cache. Adds `--refresh-context` (and `SKIP_CONTEXT_CACHE=1`) to force a rebuild, and prints `✅ Context ready (cached)` on a hit.
- **`bin/plugins sync`** warms the cache after a successful sync (best-effort; never breaks sync), so even the **first** interactive startup after a background sync is an instant hit. This is the "updated in the background" part of the issue.

## Freshness / correctness

- A sync (manual or background cron) updates `last_synced_at` → key changes → rebuild. A new local day → rebuild. Editing instructions or enabling/disabling a source → rebuild.
- "Current Time" is still printed fresh *outside* the cached block, so the AI re-derives relative times. Within a day, if nothing has re-synced, the cached context is served; `--refresh-context` / `SKIP_CONTEXT_CACHE` is the escape hatch.

## Testing

- New `test/context-cache.test.js` (15 tests): migration creates the table; key determinism + invalidation (day, targetDate, instructions, `sync_metadata`); get/set/upsert/prune; and `getDataContextCached` hit/miss/bypass + the `SKIP_CONTEXT` short-circuit.
- Full suite green locally: **692 passed, 36 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)