### PR TITLE
fix(contacts): parseVCardBasic round-trip fidelity + --postal-code option

### DIFF
--- a/bin/contacts
+++ b/bin/contacts
@@ -369,6 +369,7 @@ async function cmdAdd(options) {
   if (options.address) entry.street = options.address;
   if (options.city) entry.location_city = options.city;
   if (options.state) entry.location_state = options.state;
+  if (options.postalCode) entry.postal_code = options.postalCode;
   if (options.country) entry.location_country = options.country;
   if (options.birthday) entry.birthday = options.birthday;
   if (options.notes) entry.notes = options.notes;
@@ -457,6 +458,7 @@ async function cmdEdit(nameOrSearch, options) {
   if (options.address) updates.street = options.address;
   if (options.city) updates.location_city = options.city;
   if (options.state) updates.location_state = options.state;
+  if (options.postalCode) updates.postal_code = options.postalCode;
   if (options.country) updates.location_country = options.country;
   if (options.birthday) updates.birthday = options.birthday;
   if (options.notes) updates.notes = options.notes;
@@ -664,6 +666,7 @@ program
   .option('--address <address>', 'Street address')
   .option('--city <city>', 'City')
   .option('--state <state>', 'State/region')
+  .option('--postal-code <postalCode>', 'Postal/ZIP code')
   .option('--country <country>', 'Country')
   .option('--birthday <date>', 'Birthday (YYYY-MM-DD)')
   .option('--notes <notes>', 'Notes about the contact')
@@ -687,6 +690,7 @@ program
   .option('--address <address>', 'Update street address')
   .option('--city <city>', 'Update city')
   .option('--state <state>', 'Update state/region')
+  .option('--postal-code <postalCode>', 'Update postal/ZIP code')
   .option('--country <country>', 'Update country')
   .option('--birthday <date>', 'Update birthday (YYYY-MM-DD)')
   .option('--notes <notes>', 'Update notes')

--- a/plugins/icloud-contacts/write.js
+++ b/plugins/icloud-contacts/write.js
@@ -301,12 +301,20 @@ async function deleteContact(search) {
   };
 }
 
-// Basic vCard parser for merging
+// Basic vCard parser for merging — mirrors read.js parseVCard so round-trips are lossless
 function parseVCardBasic(vCardText) {
   const contact = {};
   const lines = vCardText.split(/\r?\n/);
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    // Handle line folding (continued lines start with SP or HT)
+    while (i + 1 < lines.length && (lines[i + 1].startsWith(' ') || lines[i + 1].startsWith('\t'))) {
+      line += lines[i + 1].substring(1);
+      i++;
+    }
+
     const colonIndex = line.indexOf(':');
     if (colonIndex <= 0) continue;
 
@@ -322,15 +330,26 @@ function parseVCardBasic(vCardText) {
       contact.last_name = parts[0]?.trim() || '';
       contact.first_name = parts[1]?.trim() || '';
     }
-    else if (key.startsWith('EMAIL')) contact.primary_email = value.trim();
-    else if (key.startsWith('TEL')) {
+    else if (key.startsWith('EMAIL') || key.includes('.EMAIL')) contact.primary_email = value.trim();
+    else if (key.startsWith('TEL') || key.includes('.TEL')) {
       if (!contact._phones) contact._phones = [];
       contact._phones.push(value.trim());
       if (!contact.primary_phone) contact.primary_phone = value.trim();
     }
-    else if (key.startsWith('ORG')) contact.organization = value.trim();
-    else if (key.startsWith('TITLE')) contact.job_title = value.trim();
-    else if (key.startsWith('BDAY')) contact.birthday = value.trim();
+    else if (key.startsWith('ORG') || key.includes('.ORG')) contact.organization = value.trim();
+    else if (key.startsWith('TITLE') || key.includes('.TITLE')) contact.job_title = value.trim();
+    else if (key.startsWith('BDAY') || key.includes('.BDAY')) contact.birthday = value.trim();
+    else if (key.startsWith('ADR') || key.includes('.ADR')) {
+      // ADR format: PO box;ext;street;city;state;postal;country
+      const parts = value.split(';');
+      if (parts.length >= 4) {
+        contact.street = parts[2]?.trim() || '';
+        contact.location_city = parts[3]?.trim() || '';
+        contact.location_state = parts[4]?.trim() || '';
+        contact.postal_code = parts[5]?.trim() || '';
+        contact.location_country = parts[6]?.trim() || '';
+      }
+    }
   }
 
   // Preserve multiple phones in metadata


### PR DESCRIPTION
Fixes #308

## What broke and why

`parseVCardBasic` in the icloud-contacts write plugin reads an existing vCard before merging updates into it. It lagged behind `read.js`'s `parseVCard` in three ways, causing silent data loss on every contact edit:

1. **Phones dropped** — only matched `key.startsWith('TEL')`, missing iCloud's grouped-property format (`item1.TEL;type=CELL;type=pref:…`). Phone was never captured, `metadata.phones` stayed `[]`, and `buildVCard` omitted the TEL line — wiping the number from iCloud.
2. **Address wiped** — no ADR branch, so existing city/state/postal_code/street were discarded and the ADR line was omitted from the rebuilt vCard.
3. **Line-folding not handled** — long values split across lines would be truncated.

## Changes

**`plugins/icloud-contacts/write.js` — `parseVCardBasic`:**
- Add line-folding support (mirrors `read.js` lines 22-27)
- Add `.includes('.TEL')` / `.includes('.EMAIL')` / `.includes('.ORG')` / `.includes('.TITLE')` to catch grouped-property keys (mirrors `read.js`)
- Add ADR parsing block to preserve street/city/state/postal_code/country (mirrors `read.js` lines 67-76)

**`bin/contacts` — `add` and `edit` commands:**
- Add `--postal-code <postalCode>` option to both; `buildVCard` already used `contact.postal_code` in the ADR field but there was no way to set it from the CLI.

## Test plan

- [ ] `bin/contacts edit "Name" --new-email x@y.com` no longer wipes the phone number
- [ ] `bin/contacts edit "Name" --phone +1…` no longer wipes city/state
- [ ] `bin/contacts edit "Name" --postal-code 12345` sets the ZIP in iCloud
- [ ] `bin/contacts add --name "…" --city X --state Y --postal-code Z` roundtrips correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)