### PR TITLE
Stop orphaning time-tracking Start markers in the inbox (#300)

### DIFF
--- a/plugins/inbox-processing/plugin.toml
+++ b/plugins/inbox-processing/plugin.toml
@@ -27,3 +27,5 @@ inbox_directory = { type = "string", default = "vault/inbox", description = "Dir
 diary_directory = { type = "string", default = "vault/diary", description = "Directory for diary files" }
 tasks_file = { type = "string", default = "vault/tasks/tasks.md", description = "Path to tasks file" }
 trash_retention_days = { type = "number", default = 7, description = "Days to keep processed files in trash before deletion" }
+dedup_window_seconds = { type = "number", default = 30, description = "Collapse same-activity Start/Stop markers fired within this many seconds (multi-device duplicates)" }
+max_unpaired_start_age_hours = { type = "number", default = 48, description = "Trash unpaired Start markers older than this many hours (0 disables aging)" }

--- a/plugins/inbox-processing/read.js
+++ b/plugins/inbox-processing/read.js
@@ -20,13 +20,18 @@ import { writeFileAtomic, writeFileAtomicCAS } from '../../src/fs-atomic.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const PROJECT_ROOT = process.env.PROJECT_ROOT || path.resolve(__dirname, '../..');
 
 const config = JSON.parse(process.env.PLUGIN_CONFIG || '{}');
 const inboxDirectory = config.inbox_directory || `${process.env.VAULT_PATH}/inbox`;
 const diaryDirectory = config.diary_directory || `${process.env.VAULT_PATH}/diary`;
 const tasksFile = config.tasks_file || `${process.env.VAULT_PATH}/tasks/tasks.md`;
 const trashRetentionDays = parseInt(config.trash_retention_days || '7', 10);
+// Multi-device sync sometimes fires the same Start/Stop within a few seconds;
+// collapse those, and age out Starts that never got a Stop. Both are tunable
+// (use ?? so an explicit 0 is honored — 0 disables the respective behavior).
+const dedupWindowSeconds = Number(config.dedup_window_seconds ?? 30);
+const maxUnpairedStartAgeHours = Number(config.max_unpaired_start_age_hours ?? 48);
 
 // Resolve paths relative to project root
 const inboxDir = path.join(PROJECT_ROOT, inboxDirectory);
@@ -522,27 +527,39 @@ function processTimeTrackingMarkers(files) {
   // Sort by timestamp
   markers.sort((a, b) => a.parsedTime - b.parsedTime);
 
-  // Collapse duplicate markers (same action within 30 seconds)
+  // Collapse near-duplicate markers. The Apple-Shortcuts workflow sometimes
+  // fires the same Start/Stop from multiple devices within a few seconds. Group
+  // by action AND description (so distinct activities are never merged), keep
+  // one representative (earliest Start / latest Stop), and remember the dropped
+  // copies so they get trashed instead of orphaning in the inbox.
   const collapsedMarkers = [];
+  const duplicateMarkerFiles = [];
 
   for (const marker of markers) {
-    const existingSameAction = collapsedMarkers.filter(m =>
+    const existing = collapsedMarkers.find(m =>
       m.action === marker.action &&
-      Math.abs(m.parsedTime - marker.parsedTime) / 1000 <= 30
+      m.description === marker.description &&
+      Math.abs(m.parsedTime - marker.parsedTime) / 1000 <= dedupWindowSeconds
     );
 
-    if (existingSameAction.length > 0) {
-      // Update existing marker with earliest start or latest stop
-      const existing = existingSameAction[0];
-      if (marker.action === 'Start' && marker.parsedTime < existing.parsedTime) {
-        existing.timestamp = marker.timestamp;
-        existing.parsedTime = marker.parsedTime;
-      } else if (marker.action === 'Stop' && marker.parsedTime > existing.parsedTime) {
-        existing.timestamp = marker.timestamp;
-        existing.parsedTime = marker.parsedTime;
-      }
-    } else {
+    if (!existing) {
       collapsedMarkers.push({ ...marker });
+      continue;
+    }
+
+    // Duplicate of an already-seen marker. Keep the better timestamp/file
+    // (earliest for Start, latest for Stop) and trash the other copy.
+    const preferNew =
+      (marker.action === 'Start' && marker.parsedTime < existing.parsedTime) ||
+      (marker.action === 'Stop' && marker.parsedTime > existing.parsedTime);
+
+    if (preferNew) {
+      duplicateMarkerFiles.push(existing.filePath);
+      existing.filePath = marker.filePath;
+      existing.timestamp = marker.timestamp;
+      existing.parsedTime = marker.parsedTime;
+    } else {
+      duplicateMarkerFiles.push(marker.filePath);
     }
   }
 
@@ -553,6 +570,11 @@ function processTimeTrackingMarkers(files) {
   const sessions = [];
   const startStack = [];
   const usedMarkers = new Set(); // Track which markers were used in sessions
+
+  // Collapsed-away duplicate copies are redundant; trash them with the rest.
+  for (const filePath of duplicateMarkerFiles) {
+    usedMarkers.add(filePath);
+  }
 
   for (const marker of collapsedMarkers) {
     if (marker.action === 'Start') {
@@ -600,10 +622,11 @@ function processTimeTrackingMarkers(files) {
   // Mark duplicate Start markers (Start markers that match existing logged sessions)
   for (const marker of collapsedMarkers) {
     if (marker.action === 'Start' && !usedMarkers.has(marker.filePath)) {
-      // Check if this Start marker matches an existing session (within 30 seconds)
+      // Check if this Start marker matches an existing session (same window we
+      // use to collapse multi-device duplicates).
       const matchesExisting = existingSessions.some(session => {
-        const timeDiff = Math.abs(marker.parsedTime - session.startTime);
-        return timeDiff < 30000; // Within 30 seconds
+        const timeDiff = Math.abs(marker.parsedTime - session.startTime) / 1000;
+        return timeDiff <= dedupWindowSeconds;
       });
 
       if (matchesExisting) {
@@ -621,8 +644,23 @@ function processTimeTrackingMarkers(files) {
     }
   }
 
-  // Only delete marker files that were used in complete sessions or cleaned up as orphaned
-  // Keep unpaired Start markers in inbox for future Stop markers
+  // Age out unpaired Start markers that are too old to ever pair. A Start that
+  // has sat in the inbox past the cutoff is unrecoverable — the activity is long
+  // over and no Stop is coming — so stop preserving it forever.
+  if (maxUnpairedStartAgeHours > 0) {
+    const maxAgeMs = maxUnpairedStartAgeHours * 60 * 60 * 1000;
+    const nowMs = Date.now();
+    for (const marker of collapsedMarkers) {
+      if (marker.action === 'Start' && !usedMarkers.has(marker.filePath) &&
+          nowMs - marker.parsedTime.getTime() > maxAgeMs) {
+        usedMarkers.add(marker.filePath);
+      }
+    }
+  }
+
+  // Trash markers used in complete sessions, collapsed duplicates, orphaned
+  // Stops, and aged-out unpaired Starts. Recent unpaired Starts stay in the
+  // inbox to await a future Stop.
   for (const marker of markers) {
     if (usedMarkers.has(marker.filePath)) {
       moveToTrash(marker.filePath);

--- a/test/inbox-processing-read.test.js
+++ b/test/inbox-processing-read.test.js
@@ -1,0 +1,142 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const readScript = path.join(repoRoot, 'plugins', 'inbox-processing', 'read.js');
+
+// ISO timestamp (no millis) offset from now by the given number of seconds.
+function isoAgo(seconds) {
+  return new Date(Date.now() - seconds * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function logFileNameForNow() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}.md`;
+}
+
+function runReadPlugin(projectRoot, pluginConfig = {}) {
+  const result = spawnSync('node', [readScript], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PROJECT_ROOT: projectRoot,
+      VAULT_PATH: path.join(projectRoot, 'vault'),
+      SOURCE_ID: 'inbox-processing/test',
+      PLUGIN_CONFIG: JSON.stringify({
+        inbox_directory: 'vault/inbox',
+        ...pluginConfig
+      })
+    }
+  });
+  const output = (result.stdout || '').trim();
+  return JSON.parse(output.split('\n').pop());
+}
+
+describe('inbox-processing time-tracking marker cleanup', () => {
+  let tempRoot;
+  let inboxDir;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'inbox-processing-read-'));
+    inboxDir = path.join(tempRoot, 'vault', 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  let counter = 0;
+  function marker(action, timestamp, description) {
+    const name = `time-tracking-${Date.now()}-${counter++}.txt`;
+    fs.writeFileSync(path.join(inboxDir, name), `${action}\n${timestamp}\n${description}\n`);
+    return name;
+  }
+
+  // Time-tracking marker files still sitting at the top of the inbox (not trashed).
+  function remainingMarkers() {
+    return fs.readdirSync(inboxDir).filter(f => f.startsWith('time-tracking-'));
+  }
+
+  function readLogLines() {
+    const logFile = path.join(tempRoot, 'vault', 'logs', 'time-tracking', logFileNameForNow());
+    if (!fs.existsSync(logFile)) return [];
+    return fs.readFileSync(logFile, 'utf-8').trim().split('\n').filter(Boolean);
+  }
+
+  test('collapses same-second multi-device duplicate Starts and pairs one session', () => {
+    const ts = isoAgo(600); // 10 min ago
+    marker('Start', ts, 'Accounting');
+    marker('Start', ts, 'Accounting');
+    marker('Start', ts, 'Accounting');
+    marker('Stop', isoAgo(0), 'Accounting');
+
+    const result = runReadPlugin(tempRoot);
+
+    expect(result.timeTrackingSessions).toBe(1);
+    expect(remainingMarkers()).toHaveLength(0); // all four files trashed, none orphaned
+    expect(readLogLines()).toHaveLength(1);
+  });
+
+  test('collapses Starts fired seconds apart, keeping the earliest start time', () => {
+    const early = isoAgo(617);
+    const late = isoAgo(600); // 17s later
+    marker('Start', late, 'Accounting');
+    marker('Start', early, 'Accounting');
+    marker('Stop', isoAgo(0), 'Accounting');
+
+    const result = runReadPlugin(tempRoot);
+
+    expect(result.timeTrackingSessions).toBe(1);
+    expect(remainingMarkers()).toHaveLength(0);
+    const lines = readLogLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].split('|')[0]).toBe(early); // earliest start wins
+  });
+
+  test('does NOT merge different activities within the window', () => {
+    const t = isoAgo(600);
+    marker('Start', t, 'Accounting');
+    marker('Start', isoAgo(595), 'Email'); // 5s later, different description
+    marker('Stop', isoAgo(60), 'Accounting');
+    marker('Stop', isoAgo(0), 'Email');
+
+    const result = runReadPlugin(tempRoot);
+
+    expect(result.timeTrackingSessions).toBe(2); // two distinct sessions, not collapsed
+    expect(remainingMarkers()).toHaveLength(0);
+    expect(readLogLines()).toHaveLength(2);
+  });
+
+  test('ages out an unpaired Start older than the cutoff', () => {
+    marker('Start', isoAgo(72 * 3600), 'Reading'); // 72h ago, no Stop
+
+    const result = runReadPlugin(tempRoot, { max_unpaired_start_age_hours: 48 });
+
+    expect(result.timeTrackingSessions).toBe(0);
+    expect(remainingMarkers()).toHaveLength(0); // aged out and trashed
+  });
+
+  test('keeps a recent unpaired Start for a future Stop', () => {
+    marker('Start', isoAgo(3600), 'Reading'); // 1h ago, no Stop
+
+    const result = runReadPlugin(tempRoot, { max_unpaired_start_age_hours: 48 });
+
+    expect(result.timeTrackingSessions).toBe(0);
+    expect(remainingMarkers()).toHaveLength(1); // still waiting for its Stop
+  });
+
+  test('trashes an orphaned Stop with no matching Start', () => {
+    marker('Stop', isoAgo(0), 'Reading');
+
+    const result = runReadPlugin(tempRoot);
+
+    expect(result.timeTrackingSessions).toBe(0);
+    expect(remainingMarkers()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #300.

## Problem

The Apple-Shortcuts time-tracking workflow sometimes fires the **same** Start from multiple devices within seconds (e.g. 3 identical "Accounting" Starts at the same second, or iPad→iPhone 17s apart). Over 2026-05-12 → 05-26 these accumulated as **89 unpaired `time-tracking-*.txt` Start markers** in `vault/inbox/` that had to be trashed by hand.

## Root cause (`plugins/inbox-processing/read.js::processTimeTrackingMarkers()`)

1. The existing "collapse duplicates" pass grouped by **action only** — so two *different* activities started within 30s would wrongly merge — and, critically, it **never recorded the collapsed-away duplicate files for trashing**. The survivor stayed in `collapsedMarkers`; the rest were silently dropped from processing and left in the inbox forever. That's the precise mechanism orphaning the files.
2. The LIFO pair-up stack leaves older copies unpaired, and unpaired Starts were preserved indefinitely — so a Start that never got a Stop never cleaned up.

## Fix

- **Description-aware collapse:** group near-duplicates by action **and** description within `dedup_window_seconds` (default 30), keep one representative (earliest Start / latest Stop), and **trash the redundant copies** instead of orphaning them.
- **Age out unpaired Starts** older than `max_unpaired_start_age_hours` (default 48). Recent Starts are still kept, so the normal same-day Start→Stop flow is unaffected. `0` disables aging.
- Reuse the dedup window for the existing dedup-against-log check so the two duplicate windows stay coupled and tunable.
- Honor `process.env.PROJECT_ROOT` (the convention already used elsewhere when invoking plugin `read.js`) so the inbox + time-log paths are relocatable — which is what makes the isolated test possible.

Both thresholds are new `plugin.toml` settings. Trashing still goes through the existing dated `.trash/<today>/` retention — nothing is hard-deleted.

## Testing

New `test/inbox-processing-read.test.js` — an end-to-end subprocess test against a temp `PROJECT_ROOT` (the real vault is never touched), covering:

1. 3 same-second identical Starts + 1 Stop → 1 session, **all** marker files trashed (none orphaned);
2. two Starts 17s apart → 1 session with the **earliest** start time logged;
3. two *different*-description Starts within the window → **2** sessions (not merged);
4. unpaired Start aged 72h → trashed;
5. unpaired Start aged 1h → **kept** for a future Stop;
6. orphan Stop → trashed.

Full suite green locally: **699 passed, 37 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)