### PR TITLE
fix(plugins): skip full context-cache warm on targeted plugin sync

### DIFF
--- a/bin/plugins
+++ b/bin/plugins
@@ -555,11 +555,14 @@ displaying results. Use 'bin/plugins sync' to force an immediate refresh.
       const context = { db, vaultPath };
       await runSyncOperation(context, pluginName, sourceName, options);
       // Warm the context cache so the next interactive startup is an instant hit.
+      // Skip for targeted syncs — only the changed plugin's data is stale.
       // Best-effort: sync must never fail because of cache warming.
-      try {
-        await getDataContextCached({ db, projectRoot: PROJECT_ROOT, bypass: true });
-      } catch {
-        // Ignore cache-warming failures
+      if (!pluginName) {
+        try {
+          await getDataContextCached({ db, projectRoot: PROJECT_ROOT, bypass: true });
+        } catch {
+          // Ignore cache-warming failures
+        }
       }
       return; // Success - exit the retry loop
     } catch (error) {


### PR DESCRIPTION
## Summary

- `bin/plugins sync <plugin>` was unconditionally calling `getDataContextCached({ bypass: true })` after every targeted sync, re-loading all 12+ data sources even though only one plugin's data changed
- Guard the cache-warm with `if (!pluginName)` so it only runs on full (no-arg) syncs

## Root cause

`cmdSync` in `bin/plugins` always warmed the full context cache after `runSyncOperation`, regardless of whether a specific plugin was targeted. Commands like `bin/projects set-review-date` each call `bin/plugins sync <plugin>`, so rescheduling several projects in one go triggered one full context rebuild per project.

## Test plan

- [ ] `bin/plugins sync markdown-projects/local` — should sync only that plugin with no `⏳ Time Tracking…` / `⏳ Diary…` etc. lines after
- [ ] `bin/plugins sync` (no args) — should still warm the full cache as before

Fixes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)