### PR TITLE
fix(vault-watcher): exclude markdown-plans to break write→watch loop

### DIFF
--- a/src/vault-watcher.js
+++ b/src/vault-watcher.js
@@ -24,13 +24,25 @@ const VAULT_DIR = getAbsoluteVaultPath();
 const DEFAULT_DEBOUNCE = 3000;
 const DEFAULT_IGNORE = ['.stfolder', '.stversions', '.backups', '.DS_Store'];
 
-// Plugins that scan the entire vault and are too expensive for real-time watching.
-// These run on the scheduler's 10-minute cron instead.
+// Plugins that must NOT be driven by the file-watcher. Two reasons:
+//
+//   1. Too expensive for real-time watching (full-vault scans).
+//   2. Generative — they WRITE into the same vault directory they watch, so
+//      watching them creates a feedback loop: the plugin's own write fires a
+//      change event, which re-runs the plugin, which writes again. With the
+//      vault Unison-synced across machines (-prefer newer), that storm spawns
+//      conflict copies and, during transient mid-sync absences, regenerates
+//      plan files from their template — clobbering hand-entered content.
+//
+// All of these run on the scheduler's 10-minute cron instead.
 const DEFAULT_EXCLUDE_PLUGINS = [
   'markdownlint-cleanup',
   'icloud-conflict-cleanup',
   'resilio-conflict-cleanup',
-  'vault-changes'
+  'vault-changes',
+  // Generative: rewrites/creates files under vault/plans, which it also
+  // watches. See https://github.com/jeffcovey/today/issues/323.
+  'markdown-plans'
 ];
 
 function loadWatcherConfig() {


### PR DESCRIPTION
Fixes #323

## Problem

Hand-written plan content keeps getting overwritten with AI-generated replacements: `year_theme`/`year_goals` (and `quarter_*`) are replaced and user body sections (`### Notes`, the Patreon table, `### 🔄 Q1 Re-evaluation`) are deleted, across all three Unison-synced machines, within minutes of being fixed.

## Root cause

`markdown-plans` is a **generative** plugin — its run rewrites/creates files under `vault/plans/`, the directory the vault-watcher watches — but it was **not** in `DEFAULT_EXCLUDE_PLUGINS`. So each write fired a change event that re-ran the plugin, which wrote again: a nonstop self-trigger loop (journal shows it firing every ~4s).

With the vault Unison-synced (`-prefer newer`), that storm spawns conflict copies (`2026_Q2_00 2.md`) and, in transient mid-sync absence windows, makes `ensureYearlyPlan` see the file as missing → regenerate it from the bare template (losing user sections) → `suggestMissingThemesAndGoals` refills the empty theme/goals with AI text. The fresh-mtime skeleton then wins `-prefer newer` and propagates everywhere. Existing CAS hardening can't catch it because there's no prior file to compare against.

## Fix

Add `markdown-plans` to `DEFAULT_EXCLUDE_PLUGINS` in `src/vault-watcher.js`, so it runs only on the scheduler's 10-minute cron — like the other write-heavy plugins already excluded. This breaks the self-trigger loop, which in turn removes the Unison conflict storm and the transient-absence regenerations. Plan creation/updates still happen on the cron, just not in response to file events.

## Testing

- `node --check src/vault-watcher.js` ✓
- `test/deploy-config.test.js` (only suite touching the watcher) — 19/19 pass ✓
- pre-commit hooks (secrets, related tests) pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)