### PR TITLE
fix(sync): reconcile task rows when a watched file is deleted

### DIFF
--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -780,12 +780,43 @@ async function _syncPluginSourceInner(plugin, sourceName, sourceConfig, context,
     };
   }
 
-  // If no entries and incremental, nothing changed
+  // Reconcile deletions for targeted (fileFilter) syncs of file-based plugins.
+  // A deleted file is requested in the fileFilter but never appears in
+  // files_processed — the plugin skips paths that no longer exist — so its rows
+  // would otherwise be orphaned in the DB and keep surfacing (e.g. in the task
+  // timer). Emptied-but-existing files already reconcile via files_processed.
+  let reconciledDeletions = 0;
+  if (fileFilter && (plugin.type === 'tasks' || plugin.type === 'time-logs')) {
+    const reconcileTable = getTableNameForType(plugin.type);
+    if (reconcileTable) {
+      const processed = new Set(filesProcessed || []);
+      const deletedFiles = fileFilter
+        .split(',')
+        .map(f => f.trim())
+        .filter(f => f && !processed.has(f));
+      if (deletedFiles.length > 0) {
+        // Escape LIKE wildcards (% _ \) in the file path so e.g. a filename with
+        // underscores can't match unrelated rows.
+        const escapeLike = (s) => s.replace(/[\\%_]/g, (c) => `\\${c}`);
+        const deleteStmt = db.prepare(
+          `DELETE FROM ${reconcileTable} WHERE source = ? AND id LIKE ? ESCAPE '\\'`
+        );
+        for (const file of deletedFiles) {
+          reconciledDeletions += deleteStmt.run(sourceId, `${sourceId}:${escapeLike(file)}:%`).changes;
+        }
+      }
+    }
+  }
+
+  // If no entries and incremental, nothing changed (unless we just reconciled
+  // away rows for a deleted file).
   if (entries.length === 0 && isIncremental) {
     return {
       success: true,
       count: 0,
-      message: `No changes since last sync`
+      message: reconciledDeletions > 0
+        ? `Removed ${reconciledDeletions} row(s) for deleted file(s)`
+        : `No changes since last sync`
     };
   }
 

--- a/test/plugin-loader.test.js
+++ b/test/plugin-loader.test.js
@@ -1,5 +1,7 @@
 import { jest } from '@jest/globals';
 import path from 'path';
+import fs from 'fs';
+import os from 'os';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -28,8 +30,10 @@ const {
   tryAcquireSyncLock,
   releaseSyncLock,
   refreshSyncLock,
-  startSyncLockHeartbeat
+  startSyncLockHeartbeat,
+  syncPluginSource
 } = await import('../src/plugin-loader.js');
+const { getSqlColumns } = await import('../src/plugin-schemas.js');
 const Database = (await import('better-sqlite3')).default;
 
 function makeLockDb() {
@@ -269,6 +273,117 @@ describe('Plugin Loader', () => {
       expect(enabled[0].plugin.name).toBe('markdown-time-tracking');
       expect(enabled[0].sources).toHaveLength(1);
       expect(enabled[0].sources[0].sourceName).toBe('local');
+    });
+  });
+
+  // Regression for #325: deleting a markdown file must remove its task rows.
+  // A deleted file is present in the targeted-sync fileFilter but never in the
+  // plugin's files_processed (the plugin skips paths that no longer exist), so
+  // before the fix its rows were orphaned and kept showing in the task timer.
+  describe('deleted-file reconciliation (targeted sync)', () => {
+    let pluginDir;
+    let plugin;
+
+    beforeAll(() => {
+      // Stub 'read' command: files whose path contains "exists" are treated as
+      // present (returned with a task + listed in files_processed); every other
+      // filtered file is treated as deleted (skipped, mirroring fs.existsSync).
+      pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tasks-stub-'));
+      const readPath = path.join(pluginDir, 'read.js');
+      fs.writeFileSync(readPath, `#!/usr/bin/env node
+const filter = (process.env.FILE_FILTER || '').split(',').map(s => s.trim()).filter(Boolean);
+const entries = [];
+const files_processed = [];
+for (const f of filter) {
+  if (f.includes('exists')) {
+    files_processed.push(f);
+    entries.push({ id: f + ':1', title: 'kept task', status: 'open' });
+  }
+}
+console.log(JSON.stringify({ entries, files_processed, incremental: true }));
+`);
+      fs.chmodSync(readPath, 0o755);
+      plugin = {
+        name: 'tasks-stub',
+        type: 'tasks',
+        _path: pluginDir,
+        commands: { read: 'read.js' }
+      };
+    });
+
+    afterAll(() => {
+      fs.rmSync(pluginDir, { recursive: true, force: true });
+    });
+
+    function makeTasksDb() {
+      const db = new Database(':memory:');
+      db.exec(`CREATE TABLE tasks (${getSqlColumns('tasks')})`);
+      db.exec(`
+        CREATE TABLE sync_metadata (
+          source TEXT PRIMARY KEY,
+          sync_locked_at TEXT,
+          sync_locked_by TEXT,
+          last_synced_at TEXT,
+          last_sync_files TEXT,
+          entries_count INTEGER,
+          extra_data TEXT
+        )
+      `);
+      return db;
+    }
+
+    const sourceId = 'tasks-stub/default';
+    const insertTask = (db, id, title) =>
+      db.prepare(`INSERT INTO tasks (id, source, title, status) VALUES (?, ?, ?, 'open')`)
+        .run(`${sourceId}:${id}`, sourceId, title);
+    const ids = (db) => db.prepare(`SELECT id FROM tasks ORDER BY id`).all().map(r => r.id);
+
+    test('removes rows for a deleted file while preserving unfiltered and updating existing files', async () => {
+      const db = makeTasksDb();
+      insertTask(db, 'vault/deleted.md:20', 'orphan');     // in filter, file gone -> delete
+      insertTask(db, 'vault/exists.md:1', 'old title');    // in filter, file present -> update
+      insertTask(db, 'vault/untouched.md:5', 'safe');      // not in filter -> keep
+
+      const result = await syncPluginSource(plugin, 'default', {}, { db, vaultPath: 'vault' }, {
+        fileFilter: 'vault/deleted.md,vault/exists.md',
+        _caller: 'test'
+      });
+
+      expect(result.success).toBe(true);
+      expect(ids(db)).toEqual([
+        `${sourceId}:vault/exists.md:1`,
+        `${sourceId}:vault/untouched.md:5`
+      ]);
+      expect(
+        db.prepare(`SELECT title FROM tasks WHERE id = ?`).get(`${sourceId}:vault/exists.md:1`).title
+      ).toBe('kept task');
+    });
+
+    test('reconciles a pure deletion (no entries returned) past the empty-incremental short-circuit', async () => {
+      const db = makeTasksDb();
+      insertTask(db, 'vault/deleted.md:20', 'orphan');
+
+      const result = await syncPluginSource(plugin, 'default', {}, { db, vaultPath: 'vault' }, {
+        fileFilter: 'vault/deleted.md',
+        _caller: 'test'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toMatch(/Removed 1 row/);
+      expect(ids(db)).toEqual([]);
+    });
+
+    test('escapes LIKE wildcards so an underscore filename cannot delete unrelated rows', async () => {
+      const db = makeTasksDb();
+      insertTask(db, 'vault/a_b.md:1', 'underscore file');  // deleted target
+      insertTask(db, 'vault/axb.md:1', 'lookalike');        // must NOT be deleted
+
+      await syncPluginSource(plugin, 'default', {}, { db, vaultPath: 'vault' }, {
+        fileFilter: 'vault/a_b.md',
+        _caller: 'test'
+      });
+
+      expect(ids(db)).toEqual([`${sourceId}:vault/axb.md:1`]);
     });
   });
 });


### PR DESCRIPTION
Fixes #325.

## Problem

Deleting a markdown file left its task rows orphaned in the database. They persisted with `status='open'` and kept being served to the task timer — e.g. **"Put cards for OlderGay.Men at Tropics"** kept appearing after its iCloud-duplicate file `repeating 2.md` was deleted. A live-DB scan found **2466 orphaned rows** across deleted `" 2.md"/" 3.md"` duplicate files (since cleaned up on the box).

## Root cause

Deletion reconciliation was keyed off *files that still exist*, so a deleted file could never be reconciled:

1. `unlink` → vault-watcher schedules a targeted incremental sync (`FILE_FILTER=<deleted file>`).
2. `markdown-tasks/read.js` filters the requested files to those that `fs.existsSync` → the deleted file drops out, so it never appears in `files_processed` and `entries` is empty.
3. `plugin-loader.js` short-circuits empty incremental results before `insertEntries` runs.
4. Even reaching `insertEntries`, the per-file delete only covers files **in** `files_processed`; the full-wipe branch needs `!filesProcessed` (an empty array is truthy). → nothing deleted.

## Fix

For targeted (`fileFilter`) syncs of file-based plugins (`tasks`, `time-logs`), treat the **requested filter list** as the reconciliation scope: any filtered file *absent* from `files_processed` is a deleted/emptied file, so its rows are deleted before the empty-incremental short-circuit. LIKE wildcards in the path are escaped (`ESCAPE '\'`) so filenames with underscores can't match unrelated rows. Emptied-but-existing files already reconcile via `files_processed`, so they're unaffected.

## Tests

Three regression tests in `test/plugin-loader.test.js` (verified to fail without the fix):
- deleted file removed, unfiltered file preserved, existing file updated
- pure deletion (no entries) reconciled past the empty-incremental short-circuit
- LIKE-wildcard escaping: an `a_b.md` deletion doesn't take out `axb.md`

Full suite: 39 suites / 729 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)