### PR TITLE
Fix task-query sort fields and double-slash Edit/save URLs

### DIFF
--- a/src/save-route.js
+++ b/src/save-route.js
@@ -22,9 +22,14 @@ export function createSaveHandler({ vaultPath, postWriteHook } = {}) {
 
   return async function saveHandler(req, res) {
     try {
-      const urlPath = Array.isArray(req.params.path)
+      const rawPath = Array.isArray(req.params.path)
         ? req.params.path.join('/')
         : req.params.path;
+      // Strip leading slashes so the splat is always treated as a
+      // vault-relative path. Without this, a leading slash (e.g. from a
+      // double-slash URL like /edit//notes/x) makes path.resolve below treat
+      // the arg as absolute and escape the vault, yielding a spurious 403.
+      const urlPath = rawPath.replace(/^\/+/, '');
       // Resolve the full path and ensure it is contained within the vault.
       // Using path.resolve (rather than path.join) collapses any `..` segments
       // before the check, and requiring the sep suffix prevents the

--- a/src/tasks-query-sort.js
+++ b/src/tasks-query-sort.js
@@ -1,0 +1,77 @@
+// Parse and apply Obsidian Tasks `sort by` directives.
+//
+// Directives come in two shapes:
+//   { type: 'field', field: 'created', reverse: false }  // sort by created [reverse]
+//   { type: 'function', expr: 'task.priority' }          // sort by function <expr>
+//
+// Date fields sort ascending by default (oldest first); `reverse` flips them.
+// `priority` is numeric (higher = more important) and sorts most-important-first
+// by default, so its reverse semantics are inverted relative to the date fields.
+
+// Map of `sort by <field>` names to the Date-valued property on a task object.
+const DATE_FIELDS = {
+  created: 'createdDate',
+  due: 'dueDate',
+  scheduled: 'scheduledDate',
+  done: 'doneDate',
+};
+
+// Parse a single `sort by ...` line into a directive, or null if unrecognized.
+export function parseSortLine(line) {
+  if (line.startsWith('sort by function ')) {
+    return { type: 'function', expr: line.replace('sort by function ', '').trim() };
+  }
+  const sortMatch = line.match(/sort by (\w+)( reverse)?/);
+  if (sortMatch) {
+    return { type: 'field', field: sortMatch[1], reverse: !!sortMatch[2] };
+  }
+  return null;
+}
+
+function evalSortFunction(task, expr, debug) {
+  try {
+    return new Function('task', `return (${expr})`)(task);
+  } catch (e) {
+    debug(`Error evaluating sort function: ${e.message}`);
+    return '';
+  }
+}
+
+// Compare two tasks for a single sort directive. Returns <0, 0, or >0.
+// Returns 0 for unknown fields so an unsupported directive is a no-op rather
+// than throwing.
+export function compareByDirective(a, b, directive, debug = () => {}) {
+  if (directive.type === 'function') {
+    const aVal = evalSortFunction(a, directive.expr, debug);
+    const bVal = evalSortFunction(b, directive.expr, debug);
+    if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
+    return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+  }
+
+  if (directive.field === 'priority') {
+    return directive.reverse ? a.priority - b.priority : b.priority - a.priority;
+  }
+
+  const dateField = DATE_FIELDS[directive.field];
+  if (dateField) {
+    const aTime = a[dateField] ? a[dateField].getTime() : 0;
+    const bTime = b[dateField] ? b[dateField].getTime() : 0;
+    return directive.reverse ? bTime - aTime : aTime - bTime;
+  }
+
+  return 0;
+}
+
+// Stably sort tasks in place by directives in priority order (first = primary).
+// Mutates and returns the array.
+export function sortTasks(tasks, sortDirectives, debug = () => {}) {
+  if (!sortDirectives || sortDirectives.length === 0) return tasks;
+  tasks.sort((a, b) => {
+    for (const directive of sortDirectives) {
+      const cmp = compareByDirective(a, b, directive, debug);
+      if (cmp !== 0) return cmp;
+    }
+    return 0;
+  });
+  return tasks;
+}

--- a/src/url-path.js
+++ b/src/url-path.js
@@ -1,0 +1,9 @@
+/**
+ * Normalize wildcard route paths to URL-style, vault-relative paths.
+ */
+export function normalizeUrlPath(rawPath) {
+  const pathText = Array.isArray(rawPath) ? rawPath.join('/') : (rawPath || '');
+  return pathText
+    .replace(/^\/+/, '')
+    .replace(/\\/g, '/');
+}

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -51,6 +51,7 @@ import { createSaveHandler } from './save-route.js';
 import { parseCreatedAfterDate, sortCreatedGroups } from './tasks-query-created.js';
 import { parseSortLine, sortTasks } from './tasks-query-sort.js';
 import { extractMostRecentNowEntry } from './now-updates-utils.js';
+import { normalizeUrlPath } from './url-path.js';
 
 // Configure marked extensions
 marked.use(gfmHeadingId());
@@ -5501,7 +5502,7 @@ app.post('/_cache/warm', async (req, res) => {
             // Use the same vault-relative, no-leading-slash convention as the
             // request route (app.get('/*path')) so the warmer and live requests
             // share cache keys and bake identical (correct) /edit/ links.
-            const urlPath = path.relative(VAULT_PATH, fullPath);
+            const urlPath = normalizeUrlPath(path.relative(VAULT_PATH, fullPath));
 
             const diskHtml = await readFromDiskCache(urlPath, mtime);
             if (diskHtml) {
@@ -6840,18 +6841,18 @@ app.get('/search', authMiddleware, async (req, res) => {
 // Edit route handler
 app.get('/edit/*path', authMiddleware, async (req, res) => {
   try {
-    const urlPath = Array.isArray(req.params.path) ? req.params.path.join('/') : req.params.path; // Get the wildcard path
-    let fullPath = path.join(VAULT_PATH, urlPath);
+    const urlPath = normalizeUrlPath(req.params.path); // Get the wildcard path
+    let fullPath = safeVaultPath(urlPath);
 
     // Security: prevent directory traversal
-    if (!fullPath.startsWith(VAULT_PATH)) {
+    if (!fullPath) {
       return res.status(403).send('Access denied');
     }
 
     // If path has no extension, try adding .md (Obsidian-style URLs)
     if (!path.extname(urlPath)) {
-      fullPath = fullPath + '.md';
-      if (!fullPath.startsWith(VAULT_PATH)) {
+      fullPath = safeVaultPath(`${urlPath}.md`);
+      if (!fullPath) {
         return res.status(403).send('Access denied');
       }
     }

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -49,6 +49,7 @@ import {
 import { getNavbar, getThemeBootstrapScript, getThemeToggleButtonHtml } from './web/navbar.js';
 import { createSaveHandler } from './save-route.js';
 import { parseCreatedAfterDate, sortCreatedGroups } from './tasks-query-created.js';
+import { parseSortLine, sortTasks } from './tasks-query-sort.js';
 import { extractMostRecentNowEntry } from './now-updates-utils.js';
 
 // Configure marked extensions
@@ -2041,7 +2042,7 @@ async function renderToml(filePath, urlPath) {
                   <h5 class="mb-0">
                     <i class="fas fa-cog me-2 text-secondary"></i>${fileName}
                   </h5>
-                  <a href="/edit/${urlPath}" class="btn btn-primary btn-sm">
+                  <a href="/edit/${urlPath.replace(/^\/+/, '')}" class="btn btn-primary btn-sm">
                     <i class="fas fa-edit me-1"></i>Edit
                   </a>
                 </div>
@@ -3788,14 +3789,9 @@ async function executeTasksQuery(query, queryContext = {}) {
     if (line.startsWith('filter by function ')) {
       const code = line.replace('filter by function ', '').trim();
       functionFilters.push(code);
-    } else if (line.startsWith('sort by function ')) {
-      const expr = line.replace('sort by function ', '').trim();
-      sortDirectives.push({ type: 'function', expr });
     } else if (line.startsWith('sort by')) {
-      const sortMatch = line.match(/sort by (\w+)( reverse)?/);
-      if (sortMatch) {
-        sortDirectives.push({ type: 'field', field: sortMatch[1], reverse: !!sortMatch[2] });
-      }
+      const directive = parseSortLine(line);
+      if (directive) sortDirectives.push(directive);
     } else if (line.startsWith('group by')) {
       groupBy = line.replace('group by ', '').trim();
     } else {
@@ -3967,41 +3963,7 @@ async function executeTasksQuery(query, queryContext = {}) {
   }
 
   // Sort - apply directives in order (first = primary, last = least significant)
-  // We reverse the directives and use stable sort so the first directive has final precedence
-  const evalSortFunction = (task, expr) => {
-    try {
-      return new Function('task', `return (${expr})`)(task);
-    } catch (e) {
-      debug(`Error evaluating sort function: ${e.message}`);
-      return '';
-    }
-  };
-
-  const compareByDirective = (a, b, directive) => {
-    if (directive.type === 'function') {
-      const aVal = evalSortFunction(a, directive.expr);
-      const bVal = evalSortFunction(b, directive.expr);
-      if (typeof aVal === 'string' && typeof bVal === 'string') return aVal.localeCompare(bVal);
-      return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
-    } else if (directive.field === 'priority') {
-      return directive.reverse ? a.priority - b.priority : b.priority - a.priority;
-    } else if (directive.field === 'done') {
-      const aTime = a.doneDate ? a.doneDate.getTime() : 0;
-      const bTime = b.doneDate ? b.doneDate.getTime() : 0;
-      return directive.reverse ? bTime - aTime : aTime - bTime;
-    }
-    return 0;
-  };
-
-  if (sortDirectives.length > 0) {
-    filtered.sort((a, b) => {
-      for (const directive of sortDirectives) {
-        const cmp = compareByDirective(a, b, directive);
-        if (cmp !== 0) return cmp;
-      }
-      return 0;
-    });
-  }
+  sortTasks(filtered, sortDirectives, debug);
 
   // Group
   if (groupBy === 'happens') {
@@ -5418,7 +5380,7 @@ ${cleanContent}
     navbar: getNavbar(fileName, 'fa-file-alt'),
     breadcrumb: breadcrumbHtml,
     pageTitle: pageTitle || fileName,
-    editUrl: `/edit/${urlPath}`,
+    editUrl: `/edit/${urlPath.replace(/^\/+/, '')}`,
     toc: toc ? `<div class="mt-2 pt-2 border-top">${toc}</div>` : '',
     properties: renderProperties(properties),
     content: htmlContent,
@@ -5536,7 +5498,10 @@ app.post('/_cache/warm', async (req, res) => {
           try {
             const stats = await fs.stat(fullPath);
             const mtime = stats.mtime.getTime();
-            const urlPath = '/' + path.relative(VAULT_PATH, fullPath);
+            // Use the same vault-relative, no-leading-slash convention as the
+            // request route (app.get('/*path')) so the warmer and live requests
+            // share cache keys and bake identical (correct) /edit/ links.
+            const urlPath = path.relative(VAULT_PATH, fullPath);
 
             const diskHtml = await readFromDiskCache(urlPath, mtime);
             if (diskHtml) {

--- a/test/save-route.test.js
+++ b/test/save-route.test.js
@@ -184,6 +184,24 @@ describe('createSaveHandler (issue #293)', () => {
     }
   });
 
+  test('leading slash in splat (double-slash URL) resolves vault-relative, not 403', async () => {
+    // Reproduces the "Save failed" bug: a /edit//notes/x URL embeds a
+    // leading-slash path into the save call (/save//plan.md). Without
+    // normalization, path.resolve treats it as absolute and escapes the vault.
+    const handler = createSaveHandler({ vaultPath });
+
+    await withServer(handler, async (base) => {
+      const res = await fetch(`${base}/save//plan.md`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'double-slash write\n' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('double-slash write\n');
+    });
+  });
+
   test('non-markdown/toml file rejected', async () => {
     fsSync.writeFileSync(path.join(vaultPath, 'notes.txt'), 'plain text\n');
     const handler = createSaveHandler({ vaultPath });

--- a/test/tasks-query-sort.test.js
+++ b/test/tasks-query-sort.test.js
@@ -1,0 +1,125 @@
+import { parseSortLine, compareByDirective, sortTasks } from '../src/tasks-query-sort.js';
+
+const d = (s) => new Date(s + 'T00:00:00');
+
+// Minimal task factory — only the fields the comparator reads.
+const task = (over = {}) => ({
+  text: over.text ?? 'task',
+  priority: over.priority ?? 0,
+  createdDate: over.createdDate ?? null,
+  dueDate: over.dueDate ?? null,
+  scheduledDate: over.scheduledDate ?? null,
+  doneDate: over.doneDate ?? null,
+});
+
+describe('parseSortLine', () => {
+  test('parses a plain field directive', () => {
+    expect(parseSortLine('sort by created')).toEqual({ type: 'field', field: 'created', reverse: false });
+  });
+
+  test('parses a reversed field directive', () => {
+    expect(parseSortLine('sort by due reverse')).toEqual({ type: 'field', field: 'due', reverse: true });
+  });
+
+  test('parses a function directive', () => {
+    expect(parseSortLine('sort by function task.priority')).toEqual({ type: 'function', expr: 'task.priority' });
+  });
+
+  test('returns null for an unrecognized line', () => {
+    expect(parseSortLine('sort by')).toBeNull();
+  });
+});
+
+describe('compareByDirective date fields', () => {
+  for (const [field, prop] of [['created', 'createdDate'], ['due', 'dueDate'], ['scheduled', 'scheduledDate'], ['done', 'doneDate']]) {
+    test(`sorts by ${field} ascending by default`, () => {
+      const older = task({ [prop]: d('2026-01-01') });
+      const newer = task({ [prop]: d('2026-06-01') });
+      expect(compareByDirective(older, newer, { type: 'field', field, reverse: false })).toBeLessThan(0);
+      expect(compareByDirective(newer, older, { type: 'field', field, reverse: false })).toBeGreaterThan(0);
+    });
+
+    test(`reverses ${field} when requested`, () => {
+      const older = task({ [prop]: d('2026-01-01') });
+      const newer = task({ [prop]: d('2026-06-01') });
+      expect(compareByDirective(older, newer, { type: 'field', field, reverse: true })).toBeGreaterThan(0);
+    });
+
+    test(`treats a missing ${field} as epoch (sorts first ascending)`, () => {
+      const none = task();
+      const dated = task({ [prop]: d('2026-01-01') });
+      expect(compareByDirective(none, dated, { type: 'field', field, reverse: false })).toBeLessThan(0);
+    });
+  }
+});
+
+describe('compareByDirective priority', () => {
+  test('sorts higher priority first by default', () => {
+    const high = task({ priority: 3 });
+    const low = task({ priority: 1 });
+    expect(compareByDirective(high, low, { type: 'field', field: 'priority', reverse: false })).toBeLessThan(0);
+  });
+
+  test('reverses to lower priority first', () => {
+    const high = task({ priority: 3 });
+    const low = task({ priority: 1 });
+    expect(compareByDirective(high, low, { type: 'field', field: 'priority', reverse: true })).toBeGreaterThan(0);
+  });
+});
+
+describe('compareByDirective function and unknown fields', () => {
+  test('compares strings via localeCompare', () => {
+    const a = task({ text: 'apple' });
+    const b = task({ text: 'banana' });
+    expect(compareByDirective(a, b, { type: 'function', expr: 'task.text' })).toBeLessThan(0);
+  });
+
+  test('compares numbers from a function', () => {
+    const a = task({ priority: 1 });
+    const b = task({ priority: 5 });
+    expect(compareByDirective(a, b, { type: 'function', expr: 'task.priority' })).toBeLessThan(0);
+  });
+
+  test('a throwing function expression is a no-op (returns empty string)', () => {
+    const a = task();
+    const b = task();
+    expect(compareByDirective(a, b, { type: 'function', expr: 'task.nope.boom' })).toBe(0);
+  });
+
+  test('an unknown field is a no-op rather than throwing', () => {
+    const a = task({ createdDate: d('2026-01-01') });
+    const b = task({ createdDate: d('2026-06-01') });
+    expect(compareByDirective(a, b, { type: 'field', field: 'bogus', reverse: false })).toBe(0);
+  });
+});
+
+describe('sortTasks', () => {
+  test('orders by created date — the originally-broken case', () => {
+    const tasks = [
+      task({ text: 'b', createdDate: d('2026-03-01') }),
+      task({ text: 'a', createdDate: d('2026-01-01') }),
+      task({ text: 'c', createdDate: d('2026-06-01') }),
+    ];
+    sortTasks(tasks, [{ type: 'field', field: 'created', reverse: false }]);
+    expect(tasks.map(t => t.text)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('applies directives in precedence order (first = primary)', () => {
+    const tasks = [
+      task({ text: 'lowprio-early', priority: 1, createdDate: d('2026-01-01') }),
+      task({ text: 'highprio-late', priority: 3, createdDate: d('2026-06-01') }),
+      task({ text: 'highprio-early', priority: 3, createdDate: d('2026-01-01') }),
+    ];
+    sortTasks(tasks, [
+      { type: 'field', field: 'priority', reverse: false },
+      { type: 'field', field: 'created', reverse: false },
+    ]);
+    expect(tasks.map(t => t.text)).toEqual(['highprio-early', 'highprio-late', 'lowprio-early']);
+  });
+
+  test('is a stable no-op with no directives', () => {
+    const tasks = [task({ text: 'x' }), task({ text: 'y' }), task({ text: 'z' })];
+    sortTasks(tasks, []);
+    expect(tasks.map(t => t.text)).toEqual(['x', 'y', 'z']);
+  });
+});

--- a/test/url-path.test.js
+++ b/test/url-path.test.js
@@ -1,0 +1,21 @@
+import path from 'path';
+import { normalizeUrlPath } from '../src/url-path.js';
+
+describe('normalizeUrlPath', () => {
+  test('normalizes leading slash in wildcard path', () => {
+    expect(normalizeUrlPath('/notes/x.md')).toBe('notes/x.md');
+  });
+
+  test('normalizes repeated leading slashes', () => {
+    expect(normalizeUrlPath('//notes/x.md')).toBe('notes/x.md');
+  });
+
+  test('normalizes path arrays from wildcard params', () => {
+    expect(normalizeUrlPath(['notes', 'x.md'])).toBe('notes/x.md');
+  });
+
+  test('normalizes windows separators to URL slashes', () => {
+    const winRelative = path.win32.relative('C:\\vault', 'C:\\vault\\notes\\x.md');
+    expect(normalizeUrlPath(winRelative)).toBe('notes/x.md');
+  });
+});


### PR DESCRIPTION
Fixes three related bugs in the tasks web view, surfaced while debugging why `/tasks/old.md`'s `sort by created` block sorted alphabetically.

## Changes
1. **`sort by created`/`due`/`scheduled` now work.** The comparator only handled `priority`/`done` and silently `return 0`'d every other field, making those sorts a stable no-op. Extracted the sort logic out of `web-server.js` into a pure, unit-tested `src/tasks-query-sort.js` driven by a `DATE_FIELDS` map.
2. **Save no longer 403s on double-slash URLs.** `/save` used `path.resolve`, so a leading-slash splat (from `/edit//notes/x`) resolved as absolute and escaped the vault → "Save failed!". Now normalized.
3. **Edit link no longer renders `//`.** The cache-warmer built `urlPath` with a leading slash, baking `/edit//notes/...` into cached HTML. Normalized at both link sites and aligned the warmer with the request-route convention.

## Testing
- New `test/tasks-query-sort.test.js` (25 tests) covering parse, every date field, priority, function exprs, and the unknown-field no-op — including a regression test for the original `sort by created` bug.
- New double-slash regression test in `test/save-route.test.js`.
- Full suite green: **41 suites / 759 tests**.
- Verified end-to-end against the live server: the served note page now renders `href="/edit/notes/..."` (single slash), zero `/edit//` links.

Note: the stale rendered-HTML cache (`.data/html-cache/`) was cleared on the droplet so links regenerate correctly.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)