### PR TITLE
Fix plan priorities rendering as [object Object]

### DIFF
--- a/src/web-server.js
+++ b/src/web-server.js
@@ -2991,7 +2991,7 @@ class DataviewAPI {
   list(items) {
     let html = '<ul class="dataview-list">\n';
     for (const item of items) {
-      html += `<li>${item}</li>\n`;
+      html += `<li>${formatListItem(item)}</li>\n`;
     }
     html += '</ul>';
     return html;
@@ -3492,6 +3492,19 @@ async function executeDQLQuery(query, vaultPath, currentFilePath, properties, al
   return `<div class="alert alert-info"><small>Unsupported Dataview query</small></div>`;
 }
 
+// Render a single frontmatter list item as text.
+// YAML parses an unquoted "- key: value" bullet as a mapping (object) rather
+// than a string, so String(item) would yield "[object Object]". Reconstruct
+// the original "key: value" text in that case.
+function formatListItem(item) {
+  if (item && typeof item === 'object' && !Array.isArray(item)) {
+    return Object.entries(item)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(', ');
+  }
+  return String(item);
+}
+
 // Execute a DQL LIST query
 async function executeDQLList(lines, vaultPath, currentFilePath, properties, allFiles) {
   const joinedQuery = lines.join(' ');
@@ -3508,7 +3521,7 @@ async function executeDQLList(lines, vaultPath, currentFilePath, properties, all
 
     let html = '<ul>\n';
     for (const item of items) {
-      html += `<li>${String(item)}</li>\n`;
+      html += `<li>${formatListItem(item)}</li>\n`;
     }
     html += '</ul>\n';
     return html;

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -3493,11 +3493,20 @@ async function executeDQLQuery(query, vaultPath, currentFilePath, properties, al
 }
 
 // Render a single frontmatter list item as text.
-// YAML parses an unquoted "- key: value" bullet as a mapping (object) rather
-// than a string, so String(item) would yield "[object Object]". Reconstruct
-// the original "key: value" text in that case.
+// YAML parses an unquoted "- key: value" bullet as a mapping (a plain object)
+// rather than a string, so String(item) would yield "[object Object]".
+// Reconstruct the original "key: value" text in that case. Restrict this to
+// plain objects only: other object types js-yaml can produce (e.g. Date from a
+// YAML timestamp) have no useful Object.entries() and must fall through to
+// String(item), which renders them correctly.
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function formatListItem(item) {
-  if (item && typeof item === 'object' && !Array.isArray(item)) {
+  if (isPlainObject(item)) {
     return Object.entries(item)
       .map(([k, v]) => `${k}: ${v}`)
       .join(', ');


### PR DESCRIPTION
## Summary

The **Theme and Priorities** section on plan pages (e.g. `/plans/2026_Q2_06_W26_00.md`) rendered each priority as the literal text `[object Object]`.

## Root cause

Each `week_priorities` bullet in the plan's YAML frontmatter contains an unquoted `: ` (colon-space):

```yaml
week_priorities:
  - Capture the week's OGM progress: close out the image pages work...
```

YAML parses `- key: value` as a **mapping**, so `js-yaml` returns an object, not a string. The DQL LIST renderer (`executeDQLList`) then did `String(item)`, which yields `"[object Object]"` for objects.

## Fix

Add a `formatListItem()` helper that reconstructs `key: value` text for object-typed items and use it in both `executeDQLList()` and the Dataview `list()` renderer. Priorities now render correctly whether or not the author quotes the colons in frontmatter.

## Verification

- `node --check src/web-server.js` passes.
- Ran `formatListItem()` against the real `2026_Q2_06_W26_00.md` frontmatter — all three priorities render as their intended text.
- Pre-commit / pre-push test hooks pass.

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)