### PR TITLE
Defend against invalid frontmatter YAML (raw frontmatter dumped into page)

### DIFF
--- a/src/frontmatter.js
+++ b/src/frontmatter.js
@@ -5,7 +5,10 @@
 // helpers parse valid frontmatter strictly and fall back to a lenient,
 // best-effort recovery so a single bad character never dumps raw frontmatter
 // into the page or breaks the Properties section / =this.* lookups.
-import yaml from 'js-yaml';
+// Namespace import: js-yaml v5 ships native ESM with named exports and no
+// default export, so `import yaml from 'js-yaml'` would throw. This form works
+// on both v4 and v5.
+import * as yaml from 'js-yaml';
 
 // Strip surrounding quotes from a lenient-parsed scalar value.
 export function stripYamlQuotes(value) {

--- a/src/frontmatter.js
+++ b/src/frontmatter.js
@@ -1,0 +1,93 @@
+// Frontmatter parsing for markdown pages.
+//
+// AI-generated plan files sometimes contain YAML that js-yaml can't parse
+// (e.g. an unquoted "key: value" colon inside a narrative summary). These
+// helpers parse valid frontmatter strictly and fall back to a lenient,
+// best-effort recovery so a single bad character never dumps raw frontmatter
+// into the page or breaks the Properties section / =this.* lookups.
+import yaml from 'js-yaml';
+
+// Strip surrounding quotes from a lenient-parsed scalar value.
+export function stripYamlQuotes(value) {
+  const trimmed = value.trim();
+  const quoted = trimmed.match(/^(["'])([\s\S]*)\1$/);
+  return quoted ? quoted[2] : trimmed;
+}
+
+// Coerce a lenient-parsed scalar to a number when it clearly is one,
+// otherwise leave it as a string (dates stay strings, matching js-yaml v5).
+export function coerceYamlScalar(value) {
+  if (/^-?\d+$/.test(value)) return parseInt(value, 10);
+  if (/^-?\d+\.\d+$/.test(value)) return parseFloat(value);
+  return value;
+}
+
+// Keys that would pollute Object.prototype if assigned; skipped by the
+// lenient parser since it handles untrusted/malformed frontmatter.
+const UNSAFE_FRONTMATTER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// Best-effort frontmatter parser used only when strict YAML parsing fails
+// (e.g. an AI-written summary containing an unquoted "key: value" colon).
+// Handles the flat "key: value" + simple "- item" list shape our frontmatter
+// uses, taking values as raw text (with light numeric coercion) so stray
+// colons can't break it.
+export function parseFrontmatterLenient(yamlText) {
+  const properties = {};
+  let currentArrayKey = null;
+
+  for (const rawLine of yamlText.split('\n')) {
+    if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
+
+    const arrayItem = rawLine.match(/^\s+-\s+(.*)$/);
+    if (arrayItem && currentArrayKey) {
+      properties[currentArrayKey].push(stripYamlQuotes(arrayItem[1]));
+      continue;
+    }
+
+    const keyValue = rawLine.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (keyValue) {
+      const [, key, value] = keyValue;
+      if (UNSAFE_FRONTMATTER_KEYS.has(key)) {
+        currentArrayKey = null;
+        continue;
+      }
+      if (value === '') {
+        // Blank value: start of a list (or a nested block we can't recover).
+        currentArrayKey = key;
+        properties[key] = [];
+      } else {
+        currentArrayKey = null;
+        properties[key] = coerceYamlScalar(stripYamlQuotes(value));
+      }
+    }
+  }
+
+  return Object.keys(properties).length > 0 ? properties : null;
+}
+
+// Parse YAML frontmatter from markdown content. Returns the parsed properties
+// (null when there is no frontmatter or nothing could be recovered) and the
+// body with the frontmatter block removed.
+export function parseFrontmatter(content) {
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { properties: null, contentWithoutFrontmatter: content };
+  }
+
+  // Always strip the frontmatter block from the body so it never renders as
+  // page text, even when parsing below fails.
+  const contentWithoutFrontmatter = content.replace(frontmatterRegex, '');
+
+  try {
+    const properties = yaml.load(match[1]);
+    return { properties, contentWithoutFrontmatter };
+  } catch (error) {
+    // Just log the message, not the full error object (too verbose for vault scanning)
+    console.error('Error parsing YAML frontmatter:', error.message || error);
+    // Recover what we can so the Properties section and =this.* still work
+    // instead of dumping raw frontmatter into the page.
+    return { properties: parseFrontmatterLenient(match[1]), contentWithoutFrontmatter };
+  }
+}

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -2798,10 +2798,15 @@ function coerceYamlScalar(value) {
   return value;
 }
 
+// Keys that would pollute Object.prototype if assigned; skipped by the
+// lenient parser since it handles untrusted/malformed frontmatter.
+const UNSAFE_FRONTMATTER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 // Best-effort frontmatter parser used only when strict YAML parsing fails
 // (e.g. an AI-written summary containing an unquoted "key: value" colon).
 // Handles the flat "key: value" + simple "- item" list shape our frontmatter
-// uses, treating every value as raw text so stray colons can't break it.
+// uses, taking values as raw text (with light numeric coercion) so stray
+// colons can't break it.
 function parseFrontmatterLenient(yamlText) {
   const properties = {};
   let currentArrayKey = null;
@@ -2818,6 +2823,10 @@ function parseFrontmatterLenient(yamlText) {
     const keyValue = rawLine.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
     if (keyValue) {
       const [, key, value] = keyValue;
+      if (UNSAFE_FRONTMATTER_KEYS.has(key)) {
+        currentArrayKey = null;
+        continue;
+      }
       if (value === '') {
         // Blank value: start of a list (or a nested block we can't recover).
         currentArrayKey = key;

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -33,6 +33,7 @@ import {
   runTasksGroupFunction
 } from './tasks-query-functions.js';
 import yaml from 'js-yaml';
+import { parseFrontmatter } from './frontmatter.js';
 import moment from 'moment';
 import { parse as parseToml } from 'smol-toml';
 import {
@@ -2781,89 +2782,6 @@ function generateTableOfContents() {
 // Convert markdown links [text](url) to HTML <a> tags in task display text
 function renderMarkdownLinks(text) {
   return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
-}
-
-// Strip surrounding quotes from a lenient-parsed scalar value.
-function stripYamlQuotes(value) {
-  const trimmed = value.trim();
-  const quoted = trimmed.match(/^(["'])([\s\S]*)\1$/);
-  return quoted ? quoted[2] : trimmed;
-}
-
-// Coerce a lenient-parsed scalar to a number when it clearly is one,
-// otherwise leave it as a string (dates stay strings, matching js-yaml v5).
-function coerceYamlScalar(value) {
-  if (/^-?\d+$/.test(value)) return parseInt(value, 10);
-  if (/^-?\d+\.\d+$/.test(value)) return parseFloat(value);
-  return value;
-}
-
-// Keys that would pollute Object.prototype if assigned; skipped by the
-// lenient parser since it handles untrusted/malformed frontmatter.
-const UNSAFE_FRONTMATTER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-// Best-effort frontmatter parser used only when strict YAML parsing fails
-// (e.g. an AI-written summary containing an unquoted "key: value" colon).
-// Handles the flat "key: value" + simple "- item" list shape our frontmatter
-// uses, taking values as raw text (with light numeric coercion) so stray
-// colons can't break it.
-function parseFrontmatterLenient(yamlText) {
-  const properties = {};
-  let currentArrayKey = null;
-
-  for (const rawLine of yamlText.split('\n')) {
-    if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
-
-    const arrayItem = rawLine.match(/^\s+-\s+(.*)$/);
-    if (arrayItem && currentArrayKey) {
-      properties[currentArrayKey].push(stripYamlQuotes(arrayItem[1]));
-      continue;
-    }
-
-    const keyValue = rawLine.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
-    if (keyValue) {
-      const [, key, value] = keyValue;
-      if (UNSAFE_FRONTMATTER_KEYS.has(key)) {
-        currentArrayKey = null;
-        continue;
-      }
-      if (value === '') {
-        // Blank value: start of a list (or a nested block we can't recover).
-        currentArrayKey = key;
-        properties[key] = [];
-      } else {
-        currentArrayKey = null;
-        properties[key] = coerceYamlScalar(stripYamlQuotes(value));
-      }
-    }
-  }
-
-  return Object.keys(properties).length > 0 ? properties : null;
-}
-
-// Parse YAML frontmatter from markdown content
-function parseFrontmatter(content) {
-  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
-  const match = content.match(frontmatterRegex);
-
-  if (!match) {
-    return { properties: null, contentWithoutFrontmatter: content };
-  }
-
-  // Always strip the frontmatter block from the body so it never renders as
-  // page text, even when parsing below fails.
-  const contentWithoutFrontmatter = content.replace(frontmatterRegex, '');
-
-  try {
-    const properties = yaml.load(match[1]);
-    return { properties, contentWithoutFrontmatter };
-  } catch (error) {
-    // Just log the message, not the full error object (too verbose for vault scanning)
-    console.error('Error parsing YAML frontmatter:', error.message || error);
-    // Recover what we can so the Properties section and =this.* still work
-    // instead of dumping raw frontmatter into the page.
-    return { properties: parseFrontmatterLenient(match[1]), contentWithoutFrontmatter };
-  }
 }
 
 // Render properties as a nice HTML card

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -32,7 +32,9 @@ import {
   runTasksFilterFunction,
   runTasksGroupFunction
 } from './tasks-query-functions.js';
-import yaml from 'js-yaml';
+// Namespace import: js-yaml v5 is native ESM with no default export, so
+// `import yaml from 'js-yaml'` throws at startup. Works on both v4 and v5.
+import * as yaml from 'js-yaml';
 import { parseFrontmatter } from './frontmatter.js';
 import moment from 'moment';
 import { parse as parseToml } from 'smol-toml';

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -2783,6 +2783,55 @@ function renderMarkdownLinks(text) {
   return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
 }
 
+// Strip surrounding quotes from a lenient-parsed scalar value.
+function stripYamlQuotes(value) {
+  const trimmed = value.trim();
+  const quoted = trimmed.match(/^(["'])([\s\S]*)\1$/);
+  return quoted ? quoted[2] : trimmed;
+}
+
+// Coerce a lenient-parsed scalar to a number when it clearly is one,
+// otherwise leave it as a string (dates stay strings, matching js-yaml v5).
+function coerceYamlScalar(value) {
+  if (/^-?\d+$/.test(value)) return parseInt(value, 10);
+  if (/^-?\d+\.\d+$/.test(value)) return parseFloat(value);
+  return value;
+}
+
+// Best-effort frontmatter parser used only when strict YAML parsing fails
+// (e.g. an AI-written summary containing an unquoted "key: value" colon).
+// Handles the flat "key: value" + simple "- item" list shape our frontmatter
+// uses, treating every value as raw text so stray colons can't break it.
+function parseFrontmatterLenient(yamlText) {
+  const properties = {};
+  let currentArrayKey = null;
+
+  for (const rawLine of yamlText.split('\n')) {
+    if (!rawLine.trim() || /^\s*#/.test(rawLine)) continue;
+
+    const arrayItem = rawLine.match(/^\s+-\s+(.*)$/);
+    if (arrayItem && currentArrayKey) {
+      properties[currentArrayKey].push(stripYamlQuotes(arrayItem[1]));
+      continue;
+    }
+
+    const keyValue = rawLine.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (keyValue) {
+      const [, key, value] = keyValue;
+      if (value === '') {
+        // Blank value: start of a list (or a nested block we can't recover).
+        currentArrayKey = key;
+        properties[key] = [];
+      } else {
+        currentArrayKey = null;
+        properties[key] = coerceYamlScalar(stripYamlQuotes(value));
+      }
+    }
+  }
+
+  return Object.keys(properties).length > 0 ? properties : null;
+}
+
 // Parse YAML frontmatter from markdown content
 function parseFrontmatter(content) {
   const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
@@ -2792,14 +2841,19 @@ function parseFrontmatter(content) {
     return { properties: null, contentWithoutFrontmatter: content };
   }
 
+  // Always strip the frontmatter block from the body so it never renders as
+  // page text, even when parsing below fails.
+  const contentWithoutFrontmatter = content.replace(frontmatterRegex, '');
+
   try {
     const properties = yaml.load(match[1]);
-    const contentWithoutFrontmatter = content.replace(frontmatterRegex, '');
     return { properties, contentWithoutFrontmatter };
   } catch (error) {
     // Just log the message, not the full error object (too verbose for vault scanning)
     console.error('Error parsing YAML frontmatter:', error.message || error);
-    return { properties: null, contentWithoutFrontmatter: content };
+    // Recover what we can so the Properties section and =this.* still work
+    // instead of dumping raw frontmatter into the page.
+    return { properties: parseFrontmatterLenient(match[1]), contentWithoutFrontmatter };
   }
 }
 

--- a/test/frontmatter.test.js
+++ b/test/frontmatter.test.js
@@ -1,0 +1,155 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  parseFrontmatter,
+  parseFrontmatterLenient,
+  stripYamlQuotes,
+  coerceYamlScalar,
+} from '../src/frontmatter.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The lenient fallback logs to console.error by design; silence it in tests.
+let errorSpy;
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('parseFrontmatter — strict (valid YAML)', () => {
+  test('parses valid frontmatter and strips it from the body', () => {
+    const content = '---\ntitle: Hello\ncount: 3\n---\n# Body\n\ntext\n';
+    const { properties, contentWithoutFrontmatter } = parseFrontmatter(content);
+    expect(properties).toEqual({ title: 'Hello', count: 3 });
+    expect(contentWithoutFrontmatter).toBe('# Body\n\ntext\n');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test('parses list values', () => {
+    const content = '---\ngoals:\n  - one\n  - two\n---\nbody\n';
+    const { properties } = parseFrontmatter(content);
+    expect(properties.goals).toEqual(['one', 'two']);
+  });
+
+  test('returns null properties and untouched content when there is no frontmatter', () => {
+    const content = '# Just a heading\n\nno frontmatter here\n';
+    const { properties, contentWithoutFrontmatter } = parseFrontmatter(content);
+    expect(properties).toBeNull();
+    expect(contentWithoutFrontmatter).toBe(content);
+  });
+});
+
+describe('parseFrontmatter — lenient fallback (malformed YAML)', () => {
+  // Reproduces the real bug: an unquoted "key: value" colon inside a scalar
+  // makes js-yaml throw, which previously dumped raw frontmatter into the page.
+  const malformed =
+    '---\n' +
+    'quarter: Q2\n' +
+    'year: 2026\n' +
+    'start_date: 2026-04-01\n' +
+    'theme: Health, Legacy, and Growth\n' +
+    'goals:\n' +
+    '  - Finish the weight loss project\n' +
+    '  - Launch campaign: target audience and budget\n' +
+    'summary: The quarter had genuine warmth: language learning claimed the most hours.\n' +
+    '---\n' +
+    '# Q2 2026\n\nbody\n';
+
+  test('strips the frontmatter block from the body even though YAML parsing failed', () => {
+    const { contentWithoutFrontmatter } = parseFrontmatter(malformed);
+    expect(contentWithoutFrontmatter).toBe('# Q2 2026\n\nbody\n');
+    expect(contentWithoutFrontmatter).not.toContain('summary:');
+    expect(errorSpy).toHaveBeenCalled(); // fallback was triggered
+  });
+
+  test('recovers scalar, numeric, and list properties', () => {
+    const { properties } = parseFrontmatter(malformed);
+    expect(properties.quarter).toBe('Q2');
+    expect(properties.year).toBe(2026); // numeric coercion
+    expect(properties.start_date).toBe('2026-04-01'); // date stays a string
+    expect(properties.theme).toBe('Health, Legacy, and Growth');
+    expect(properties.goals).toHaveLength(2);
+  });
+
+  test('preserves colons inside recovered values instead of choking on them', () => {
+    const { properties } = parseFrontmatter(malformed);
+    expect(properties.summary).toBe(
+      'The quarter had genuine warmth: language learning claimed the most hours.'
+    );
+    expect(properties.goals[1]).toBe('Launch campaign: target audience and budget');
+  });
+});
+
+describe('parseFrontmatterLenient', () => {
+  test('returns null when nothing can be recovered', () => {
+    expect(parseFrontmatterLenient('')).toBeNull();
+    expect(parseFrontmatterLenient('   \n# only a comment\n')).toBeNull();
+  });
+
+  test('does not allow prototype pollution from malicious keys', () => {
+    const text = [
+      '__proto__: polluted',
+      'constructor: nope',
+      'prototype: nope',
+      'safe_key: kept',
+    ].join('\n');
+
+    const props = parseFrontmatterLenient(text);
+
+    // Global prototype must be untouched.
+    expect({}.polluted).toBeUndefined();
+    expect(Object.prototype.polluted).toBeUndefined();
+    // Dangerous keys are skipped; only the safe key survives.
+    expect(Object.keys(props)).toEqual(['safe_key']);
+    expect(props.safe_key).toBe('kept');
+    expect(Object.getPrototypeOf(props)).toBe(Object.prototype);
+  });
+
+  test('ignores blank lines and comments', () => {
+    const text = '# heading comment\n\nkey: value\n\n# trailing\n';
+    expect(parseFrontmatterLenient(text)).toEqual({ key: 'value' });
+  });
+});
+
+describe('stripYamlQuotes', () => {
+  test('removes matching single or double quotes', () => {
+    expect(stripYamlQuotes('"hello"')).toBe('hello');
+    expect(stripYamlQuotes("'hello'")).toBe('hello');
+    expect(stripYamlQuotes('  "spaced"  ')).toBe('spaced');
+  });
+  test('leaves unquoted or mismatched values alone', () => {
+    expect(stripYamlQuotes('plain')).toBe('plain');
+    expect(stripYamlQuotes('"mismatch\'')).toBe('"mismatch\'');
+  });
+});
+
+describe('coerceYamlScalar', () => {
+  test('coerces integers and floats, leaves other strings intact', () => {
+    expect(coerceYamlScalar('2026')).toBe(2026);
+    expect(coerceYamlScalar('-3')).toBe(-3);
+    expect(coerceYamlScalar('1.5')).toBe(1.5);
+    expect(coerceYamlScalar('2026-04-01')).toBe('2026-04-01'); // date-like stays string
+    expect(coerceYamlScalar('Q2')).toBe('Q2');
+  });
+});
+
+describe('regression: real broken quarterly plan file', () => {
+  const realFile = path.join(__dirname, '..', 'vault', 'plans', '2026_Q2_00.md');
+
+  (fs.existsSync(realFile) ? test : test.skip)(
+    'recovers properties and strips frontmatter for the real file',
+    () => {
+      const content = fs.readFileSync(realFile, 'utf8');
+      const { properties, contentWithoutFrontmatter } = parseFrontmatter(content);
+      expect(properties).not.toBeNull();
+      expect(properties.quarter_theme).toBeTruthy();
+      expect(Array.isArray(properties.quarter_goals)).toBe(true);
+      expect(typeof properties.quarter_summary).toBe('string');
+      expect(contentWithoutFrontmatter).not.toContain('quarter_summary:');
+    }
+  );
+});


### PR DESCRIPTION
## Summary

On `/plans/2026_Q2_00.md` the frontmatter renders as body text instead of in the collapsed **Properties** section, and `=this.quarter_theme` / `=this.quarter_summary` render literally.

**Root cause:** the AI-generated `quarter_summary` contains an unquoted `: ` (colon-space) — `...genuine warmth: language learning...`. YAML reads that mid-scalar `: ` as a nested mapping and **throws** (`bad indentation of a mapping entry`) on both js-yaml v4 and v5 — it's a syntax error, not a schema difference. `parseFrontmatter()` caught the throw but returned `properties: null` **and left the frontmatter in the body**, producing both symptoms.

## Approach

The narratives are AI-written, so we **defend against malformed YAML** rather than trying to prevent it (no vault edits, no generator changes):

1. Always **strip** the frontmatter block from the body, even on parse failure — raw YAML never renders as page text.
2. On failure, recover properties via a **lenient line-based fallback parser** (flat `key: value` scalars + simple `- item` lists, every value taken as raw text so stray colons can't break it), so the Properties section and `=this.*` still work.

The fallback runs **only** when strict parsing throws, so valid files use the unchanged strict path. Complements #351/#352 (a colon in a single list item that still parses) — this covers a colon that fails the *whole* parse.

## Verification

- Exercised the exact shipped functions against the real files: broken quarterly recovers all 8 keys, strips the body, and resolves `=this.quarter_theme` → "Health, Legacy, and Growth" and `=this.quarter_summary`; valid weekly plan unchanged (strict path).
- Full test suite green: **763 passed / 42 suites**.

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)