### PR TITLE
fix(markdown-projects): skip attachment dirs matching a same-named project file

### DIFF
--- a/plugins/markdown-projects/read.js
+++ b/plugins/markdown-projects/read.js
@@ -72,6 +72,12 @@ function findProjectFiles(dir, relativeTo = dir) {
   try {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
 
+    // Build a set of .md basenames in this directory so attachment-dir checks
+    // are O(1) in-memory lookups rather than per-entry existsSync calls.
+    const mdBasenames = new Set(
+      entries.filter(e => e.isFile() && e.name.endsWith('.md')).map(e => e.name.slice(0, -3))
+    );
+
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       const relativePath = path.relative(relativeTo, fullPath);
@@ -83,7 +89,7 @@ function findProjectFiles(dir, relativeTo = dir) {
 
       if (entry.isDirectory()) {
         // Skip attachment directories (a dir whose name matches a sibling .md project file)
-        if (fs.existsSync(path.join(dir, entry.name + '.md'))) {
+        if (mdBasenames.has(entry.name)) {
           continue;
         }
         // Recurse into subdirectories

--- a/plugins/markdown-projects/read.js
+++ b/plugins/markdown-projects/read.js
@@ -82,6 +82,10 @@ function findProjectFiles(dir, relativeTo = dir) {
       }
 
       if (entry.isDirectory()) {
+        // Skip attachment directories (a dir whose name matches a sibling .md project file)
+        if (fs.existsSync(path.join(dir, entry.name + '.md'))) {
+          continue;
+        }
         // Recurse into subdirectories
         files.push(...findProjectFiles(fullPath, relativeTo));
       } else if (entry.isFile() && entry.name.endsWith('.md')) {


### PR DESCRIPTION
## Summary

- Directories whose name matches a sibling `.md` project file (e.g. `financial-improvement-2026/` alongside `financial-improvement-2026.md`) are attachment folders, not project containers
- `findProjectFiles` now skips recursing into them, so sub-documents like `register-analysis-summary.md` and `ogm-poster-instructions.md` no longer appear as spurious projects in `bin/projects list`
- Named subdirectories without a matching `.md` file (e.g. `completed/`) are unaffected

## Test plan

- [ ] `bin/projects list --status active` no longer shows junk entries (register analysis summary, bathroom renovation estimate, poster files, etc.)
- [ ] `bin/projects list --status completed` still shows projects from `vault/projects/completed/`
- [ ] Projects with attachment directories (e.g. Financial Improvement 2026) still appear correctly

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)