### PR TITLE
fix(tasks): regenerate recurring tasks with a #tag between the rule and date

### DIFF
--- a/src/web-server.js
+++ b/src/web-server.js
@@ -7066,7 +7066,10 @@ app.post('/task/toggle', authMiddleware, async (req, res) => {
     debug(`[TASK] Processing task from file: "${taskLine}"`);
 
     // Check if this is a recurring task (has 🔁 pattern)
-    const recurringMatch = taskLine.match(/🔁\s+(.+?)(?:\s+(?:⏳|📅|➕)|$)/);
+    // Stop capturing at the next date token OR a #tag — a tag placed between
+    // the rule and the date would otherwise be swept into the pattern and
+    // break calculateNextRecurrence (matches plugins/markdown-tasks/read.js).
+    const recurringMatch = taskLine.match(/🔁\s+(.+?)(?:\s+(?:⏳|📅|➕|#)|$)/);
     const isRecurring = !!recurringMatch;
     let newTaskLine = null;
 

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -6972,6 +6972,13 @@ app.post('/toggle-checkbox/*path', authMiddleware, async (req, res) => {
 });
 
 // Save route handler
+// Obsidian Tasks date/metadata emoji that terminate a 🔁 recurrence rule.
+// Kept in one place so the /task/toggle (parse) and /task/edit (preserve)
+// routes can't drift on which tokens end the rule — a mismatch here silently
+// breaks recurring-task regeneration (see issue #358). Alternation, not a
+// character class, so multi-code-unit emoji (📅 🛫) match correctly.
+const RECURRENCE_TERMINATOR_TOKENS = ['⏳', '📅', '🛫', '✅', '➕'];
+
 // Helper function to calculate next recurrence date
 function calculateNextRecurrence(pattern, fromDate) {
   // Parse patterns like:
@@ -7065,11 +7072,13 @@ app.post('/task/toggle', authMiddleware, async (req, res) => {
     // Note: markdown_tasks cache was removed - proceeding with file version directly
     debug(`[TASK] Processing task from file: "${taskLine}"`);
 
-    // Check if this is a recurring task (has 🔁 pattern)
-    // Stop capturing at the next date token OR a #tag — a tag placed between
-    // the rule and the date would otherwise be swept into the pattern and
-    // break calculateNextRecurrence (matches plugins/markdown-tasks/read.js).
-    const recurringMatch = taskLine.match(/🔁\s+(.+?)(?:\s+(?:⏳|📅|➕|#)|$)/);
+    // Check if this is a recurring task (has 🔁 pattern).
+    // Stop capturing at the next date token (RECURRENCE_TERMINATOR_TOKENS) OR a
+    // #tag — anything placed between the rule and a date would otherwise be
+    // swept into the pattern and break calculateNextRecurrence (issue #358).
+    const recurringMatch = taskLine.match(
+      new RegExp(`🔁\\s+(.+?)(?:\\s+(?:${RECURRENCE_TERMINATOR_TOKENS.join('|')}|#)|$)`)
+    );
     const isRecurring = !!recurringMatch;
     let newTaskLine = null;
 
@@ -7224,7 +7233,9 @@ app.post('/task/edit', authMiddleware, async (req, res) => {
     const priorityEmoji = priority && priorityEmojis[priority] ? priorityEmojis[priority] : '';
 
     // Preserve recurrence pattern from original line (stop at next date emoji or end)
-    const recurringMatch = taskLine.match(/🔁\s+[^⏳📅🛫✅➕\n]+/);
+    const recurringMatch = taskLine.match(
+      new RegExp(`🔁\\s+[^${RECURRENCE_TERMINATOR_TOKENS.join('')}\\n]+`)
+    );
     const recurrence = recurringMatch ? recurringMatch[0].trim() : '';
 
     // Preserve creation date from original line

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -6978,6 +6978,7 @@ app.post('/toggle-checkbox/*path', authMiddleware, async (req, res) => {
 // breaks recurring-task regeneration (see issue #358). Alternation, not a
 // character class, so multi-code-unit emoji (📅 🛫) match correctly.
 const RECURRENCE_TERMINATOR_TOKENS = ['⏳', '📅', '🛫', '✅', '➕'];
+const RECURRENCE_TERMINATOR_PATTERN = `${RECURRENCE_TERMINATOR_TOKENS.join('|')}|#`;
 
 // Helper function to calculate next recurrence date
 function calculateNextRecurrence(pattern, fromDate) {
@@ -7077,7 +7078,7 @@ app.post('/task/toggle', authMiddleware, async (req, res) => {
     // #tag — anything placed between the rule and a date would otherwise be
     // swept into the pattern and break calculateNextRecurrence (issue #358).
     const recurringMatch = taskLine.match(
-      new RegExp(`🔁\\s+(.+?)(?:\\s+(?:${RECURRENCE_TERMINATOR_TOKENS.join('|')}|#)|$)`)
+      new RegExp(`🔁\\s+(.+?)(?:\\s+(?:${RECURRENCE_TERMINATOR_PATTERN})|$)`)
     );
     const isRecurring = !!recurringMatch;
     let newTaskLine = null;
@@ -7232,11 +7233,11 @@ app.post('/task/edit', authMiddleware, async (req, res) => {
     const priorityEmojis = { highest: '🔺', high: '⏫', medium: '🔼', low: '🔽', lowest: '⏬' };
     const priorityEmoji = priority && priorityEmojis[priority] ? priorityEmojis[priority] : '';
 
-    // Preserve recurrence pattern from original line (stop at next date emoji or end)
+    // Preserve recurrence pattern from original line (stop at next date token, #tag, or end)
     const recurringMatch = taskLine.match(
-      new RegExp(`🔁\\s+[^${RECURRENCE_TERMINATOR_TOKENS.join('')}\\n]+`)
+      new RegExp(`🔁\\s+(.+?)(?:\\s+(?:${RECURRENCE_TERMINATOR_PATTERN})|$)`)
     );
-    const recurrence = recurringMatch ? recurringMatch[0].trim() : '';
+    const recurrence = recurringMatch ? `🔁 ${recurringMatch[1].trim()}` : '';
 
     // Preserve creation date from original line
     const creationMatch = taskLine.match(/➕\s*(\d{4}-\d{2}-\d{2})/);

--- a/test/fixtures/task-toggle-fixture.md
+++ b/test/fixtures/task-toggle-fixture.md
@@ -7,3 +7,5 @@ Do not modify manually.
 
 - [ ] Test task for toggle testing #test ⏳ 2099-12-31 ➕ 2025-01-01
 - [ ] Another test task #test
+- [ ] Recurring with tag before date 🔁 every 6 months when done #test ⏳ 2099-01-01 ➕ 2025-01-01
+- [ ] Recurring with start date after rule 🔁 every week 🛫 2099-01-01 ⏳ 2099-01-08 ➕ 2025-01-01

--- a/test/web-server-tasks.test.js
+++ b/test/web-server-tasks.test.js
@@ -550,6 +550,34 @@ describe('Task Edit API', () => {
       expect(result.updatedLine).toContain('➕ 2025-01-01');
     });
 
+    test('should preserve recurrence without duplicating a tag when editing a recurring task with #tag before date', async () => {
+      const running = await isServerConfiguredForTests();
+      if (!running) return;
+
+      const response = await fetchWithAuth(`${BASE_URL}/task/edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          filePath: TEST_FILE,
+          lineNumber: RECUR_TAG_LINE,
+          title: 'Recurring with tag before date (edited)',
+          scheduledDate: '2099-01-01',
+          tags: ['#test'],
+          completed: false
+        })
+      });
+
+      expect(response.ok).toBe(true);
+      const result = await response.json();
+      expect(result.success).toBe(true);
+      expect(result.updatedLine).toContain('🔁 every 6 months when done');
+      expect(result.updatedLine.match(/#test/g)).toHaveLength(1);
+
+      const taskLine = await readTaskLine(RECUR_TAG_LINE);
+      expect(taskLine).toContain('🔁 every 6 months when done');
+      expect(taskLine.match(/#test/g)).toHaveLength(1);
+    });
+
     test('should return 400 for missing title', async () => {
       const running = await isServerConfiguredForTests();
       if (!running) return;

--- a/test/web-server-tasks.test.js
+++ b/test/web-server-tasks.test.js
@@ -15,6 +15,7 @@ const VAULT_PATH = 'test/fixtures'; // Tests expect server to use this as VAULT_
 const TEST_FILE = 'task-toggle-fixture.md';
 const TEST_FILE_PATH = path.join(VAULT_PATH, TEST_FILE);
 const TEST_LINE = 8; // "Test task for toggle testing" - stable fixture line
+const RECUR_TAG_LINE = 10; // recurring task with a #tag between the 🔁 rule and the ⏳ date
 
 // Original fixture content for reset
 const FIXTURE_CONTENT = `# Test Tasks
@@ -26,6 +27,7 @@ Do not modify manually.
 
 - [ ] Test task for toggle testing #test ⏳ 2099-12-31 ➕ 2025-01-01
 - [ ] Another test task #test
+- [ ] Recurring with tag before date 🔁 every 6 months when done #test ⏳ 2099-01-01 ➕ 2025-01-01
 `;
 
 // Reset fixture to clean state
@@ -349,6 +351,43 @@ describe('Task Toggle - Edge Cases', () => {
     if (hasScheduledDate) expect(result.updatedLine).toContain('⏳');
     if (hasCreatedDate) expect(result.updatedLine).toContain('➕');
     if (hasPriority) expect(result.updatedLine).toMatch(/⏫|🔼/);
+  });
+
+  // Regression: a #tag placed between the 🔁 rule and the date used to get
+  // swept into the recurrence pattern, breaking parsing so no new occurrence
+  // was created. See issue #358.
+  test('should regenerate a recurring task with a #tag between the rule and the date', async () => {
+    const running = await isServerConfiguredForTests();
+    if (!running) return;
+
+    // Complete the recurring task
+    const response = await fetchWithAuth(`${BASE_URL}/task/toggle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filePath: TEST_FILE,
+        lineNumber: RECUR_TAG_LINE,
+        completed: true
+      })
+    });
+
+    expect(response.ok).toBe(true);
+    const result = await response.json();
+    expect(result.updatedLine).toMatch(/- \[x\]/);
+
+    // The file should now contain BOTH the completed occurrence and a freshly
+    // generated, unchecked next occurrence.
+    const content = await fs.readFile(TEST_FILE_PATH, 'utf-8');
+    const lines = content.split('\n');
+    const matching = lines.filter(l => l.includes('Recurring with tag before date'));
+    const completed = matching.filter(l => /- \[x\]/.test(l));
+    const regenerated = matching.filter(l => /- \[ \]/.test(l));
+
+    expect(completed).toHaveLength(1);
+    expect(regenerated).toHaveLength(1);
+    expect(regenerated[0]).toContain('🔁 every 6 months');
+    expect(regenerated[0]).toContain('⏳');
+    expect(regenerated[0]).not.toContain('✅');
   });
 });
 

--- a/test/web-server-tasks.test.js
+++ b/test/web-server-tasks.test.js
@@ -16,6 +16,7 @@ const TEST_FILE = 'task-toggle-fixture.md';
 const TEST_FILE_PATH = path.join(VAULT_PATH, TEST_FILE);
 const TEST_LINE = 8; // "Test task for toggle testing" - stable fixture line
 const RECUR_TAG_LINE = 10; // recurring task with a #tag between the 🔁 rule and the ⏳ date
+const RECUR_START_LINE = 11; // recurring task with a 🛫 start date immediately after the rule
 
 // Original fixture content for reset
 const FIXTURE_CONTENT = `# Test Tasks
@@ -28,6 +29,7 @@ Do not modify manually.
 - [ ] Test task for toggle testing #test ⏳ 2099-12-31 ➕ 2025-01-01
 - [ ] Another test task #test
 - [ ] Recurring with tag before date 🔁 every 6 months when done #test ⏳ 2099-01-01 ➕ 2025-01-01
+- [ ] Recurring with start date after rule 🔁 every week 🛫 2099-01-01 ⏳ 2099-01-08 ➕ 2025-01-01
 `;
 
 // Reset fixture to clean state
@@ -373,6 +375,7 @@ describe('Task Toggle - Edge Cases', () => {
 
     expect(response.ok).toBe(true);
     const result = await response.json();
+    expect(result.success).toBe(true);
     expect(result.updatedLine).toMatch(/- \[x\]/);
 
     // The file should now contain BOTH the completed occurrence and a freshly
@@ -387,6 +390,39 @@ describe('Task Toggle - Edge Cases', () => {
     expect(regenerated).toHaveLength(1);
     expect(regenerated[0]).toContain('🔁 every 6 months');
     expect(regenerated[0]).toContain('⏳');
+    expect(regenerated[0]).not.toContain('✅');
+  });
+
+  // Regression: a 🛫 start-date token immediately after the 🔁 rule used to be
+  // swept into the recurrence pattern (🛫 is a date token but wasn't a stop),
+  // breaking parsing so no new occurrence was created. See issue #358.
+  test('should regenerate a recurring task with a 🛫 start date after the rule', async () => {
+    const running = await isServerConfiguredForTests();
+    if (!running) return;
+
+    const response = await fetchWithAuth(`${BASE_URL}/task/toggle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filePath: TEST_FILE,
+        lineNumber: RECUR_START_LINE,
+        completed: true
+      })
+    });
+
+    expect(response.ok).toBe(true);
+    const result = await response.json();
+    expect(result.success).toBe(true);
+    expect(result.updatedLine).toMatch(/- \[x\]/);
+
+    const content = await fs.readFile(TEST_FILE_PATH, 'utf-8');
+    const lines = content.split('\n');
+    const matching = lines.filter(l => l.includes('Recurring with start date after rule'));
+    const regenerated = matching.filter(l => /- \[ \]/.test(l));
+
+    expect(matching.filter(l => /- \[x\]/.test(l))).toHaveLength(1);
+    expect(regenerated).toHaveLength(1);
+    expect(regenerated[0]).toContain('🔁 every week');
     expect(regenerated[0]).not.toContain('✅');
   });
 });


### PR DESCRIPTION
Fixes #358

## Problem

Checking off a recurring task did not create the next occurrence when a `#tag` sat between the `🔁` rule and the following date token. Real example from `vault/tasks/repeating.md`:

```
- [ ] Check that https://oldergay.men/privacy is up-to-date with services we use 🔼 ➕ 2026-06-15 🔁 every 6 months when done #stage/back-stage ⏳ 2026-07-01
```

Completing it marked the task `[x]` but generated no new occurrence.

## Root cause

`POST /task/toggle` extracted the rule with `/🔁\s+(.+?)(?:\s+(?:⏳|📅|➕)|$)/` (`src/web-server.js`), which stops only at `⏳`/`📅`/`➕` — not at a `#tag`. The captured pattern became `every 6 months when done #stage/back-stage`, which then failed the strict `^every … unit$` match in `calculateNextRecurrence` (the trailing tag also defeated the end-anchored `when done` strip). Result: `null` → no regeneration.

The `every 6 months` syntax itself is fully supported; only the tag placement triggered the bug. The DB-sync parser in `plugins/markdown-tasks/read.js` already handled this correctly via `[^\s#]`.

## Fix

Add `#` to the delimiter set so extraction stops at a tag too:

```js
const recurringMatch = taskLine.match(/🔁\s+(.+?)(?:\s+(?:⏳|📅|➕|#)|$)/);
```

## Verification

- Ran the real `calculateNextRecurrence` + the updated regex from source against the exact reported line: captures `every 6 months when done` → next occurrence `2027-01-10` (previously no match).
- Added a regression test in `test/web-server-tasks.test.js` (toggle a recurring task with a tag between the rule and the date; assert both a completed occurrence and a fresh unchecked one exist). `calculateNextRecurrence` and this path previously had no test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)