### PR TITLE
build(deps): Bump ai to 7.0.22 and ollama-ai-provider-v2 to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@inkjs/ui": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.6.0",
-        "ai": "^6.0.208",
+        "ai": "^7.0.22",
         "better-sqlite3": "^12.11.1",
         "better-sqlite3-session-store": "^0.1.0",
         "canvas": "^3.2.3",
@@ -115,17 +115,47 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.133",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
-      "integrity": "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.16.tgz",
+      "integrity": "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
+      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1798,13 +1828,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
       "license": "MIT",
@@ -2575,18 +2598,47 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.208",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.208.tgz",
-      "integrity": "sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.22.tgz",
+      "integrity": "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.133",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.16",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
+      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "marked-highlight": "^2.2.3",
         "moment": "^2.30.1",
         "node-cron": "^4.6.0",
-        "ollama-ai-provider-v2": "^3.6.0",
+        "ollama-ai-provider-v2": "^4.0.1",
         "pdf-lib": "^1.17.1",
         "picocolors": "^1.1.1",
         "puppeteer": "^25.3.0",
@@ -84,36 +84,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
-      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
-      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/gateway": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.16.tgz",
@@ -123,36 +93,6 @@
         "@ai-sdk/provider": "4.0.3",
         "@ai-sdk/provider-utils": "5.0.7",
         "@vercel/oidc": "3.2.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
-      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
-      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=22"
@@ -177,36 +117,6 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
-      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
-      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/openai": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.11.tgz",
@@ -223,7 +133,7 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+    "node_modules/@ai-sdk/provider": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
       "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
@@ -235,7 +145,7 @@
         "node": ">=22"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+    "node_modules/@ai-sdk/provider-utils": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
       "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
@@ -248,33 +158,6 @@
       },
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
-      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -2606,36 +2489,6 @@
         "@ai-sdk/gateway": "4.0.16",
         "@ai-sdk/provider": "4.0.3",
         "@ai-sdk/provider-utils": "5.0.7"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
-      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
-      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.3",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=22"
@@ -7956,23 +7809,23 @@
       }
     },
     "node_modules/ollama-ai-provider-v2": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-3.6.0.tgz",
-      "integrity": "sha512-1Om3FVJYhBwkAr5kQ+BX1s/tdVdtVdoFQWrX4PBQHDHPISyGt24CjhtggEjUYpy5ait0YeVfZwEpIYjgD8Ih7Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-4.0.1.tgz",
+      "integrity": "sha512-JHw/Knt4kOTSwQ0oqorbdgzukK6iE73U3MPUyOuCEBpAQGAzm80CQDwyaXMwF80yFjY21RY9qfzkoLyPFFts/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.10",
-        "@ai-sdk/provider-utils": "^4.0.27"
+        "@ai-sdk/provider": "^4.0.2",
+        "@ai-sdk/provider-utils": "^5.0.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "type": "Buy Me a Coffee",
         "url": "https://buymeacoffee.com/nordwestt"
       },
       "peerDependencies": {
-        "ai": "^5.0.0 || ^6.0.0",
+        "ai": "^7.0.0",
         "zod": "^4.0.16"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "marked-highlight": "^2.2.3",
     "moment": "^2.30.1",
     "node-cron": "^4.6.0",
-    "ollama-ai-provider-v2": "^3.6.0",
+    "ollama-ai-provider-v2": "^4.0.1",
     "pdf-lib": "^1.17.1",
     "picocolors": "^1.1.1",
     "puppeteer": "^25.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@inkjs/ui": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "adm-zip": "^0.6.0",
-    "ai": "^6.0.208",
+    "ai": "^7.0.22",
     "better-sqlite3": "^12.11.1",
     "better-sqlite3-session-store": "^0.1.0",
     "canvas": "^3.2.3",


### PR DESCRIPTION
Supersedes #367 and #362, which each fail CI because they cannot land independently.

## Why they were blocked

`ollama-ai-provider-v2` peer-requires a matching `ai` major:

| version | peer requirement |
|---|---|
| `ollama-ai-provider-v2@3.6.0` (current) | `ai@^5 \|\| ^6` |
| `ollama-ai-provider-v2@4.0.1` | `ai@^7` |

Bumping `ai` alone (#367) breaks the 3.x peer; bumping ollama alone (#362) breaks against `ai@6`. Both fail `npm ci` with ERESOLVE — which is why *all three* checks failed on each PR. The install step never ran, so the test/lint/audit failures were collateral, not real regressions.

## Verification

- `npm install` resolves cleanly with both bumped together
- **778 tests pass** (43/43 suites)
- `npm audit --audit-level=high` clean (one moderate transitive dev-only `js-yaml` finding, below CI threshold)
- Only 4 SDK symbols are used repo-wide — `generateText`, `streamText` (`src/ai-provider.js`), `tool` (`src/ai-chat/tools.js`), `createOllama` (`src/ai-provider.js`) — all still exported by v7, smoke-tested against the installed tree.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)