### PR TITLE
fix(ai): pass maxOutputTokens/stopWhen so token caps and tool loops actually apply

### DIFF
--- a/src/ai-provider.js
+++ b/src/ai-provider.js
@@ -25,7 +25,7 @@
 // Suppress AI SDK compatibility warnings (e.g., ollama v2 specification mode)
 globalThis.AI_SDK_LOG_WARNINGS = false;
 
-import { generateText, streamText } from 'ai';
+import { generateText, streamText, stepCountIs } from 'ai';
 import { spawnSync, spawn } from 'child_process';
 import { randomBytes } from 'crypto';
 import { existsSync, writeFileSync, unlinkSync } from 'fs';
@@ -483,15 +483,16 @@ export async function createCompletion(options) {
     model,
     system: options.system,
     messages: options.messages || [],
-    maxTokens: options.maxTokens || 1000,
+    maxOutputTokens: options.maxTokens || 1000,
     temperature: options.temperature ?? 0,
   };
 
   // Add tools if provided
   if (options.tools) {
+    const maxSteps = options.maxSteps || 5;
     genOptions.tools = options.tools;
-    genOptions.maxSteps = options.maxSteps || 5;
-    console.log('[AI Provider] createCompletion with tools:', Object.keys(options.tools), 'maxSteps:', genOptions.maxSteps);
+    genOptions.stopWhen = stepCountIs(maxSteps);
+    console.log('[AI Provider] createCompletion with tools:', Object.keys(options.tools), 'maxSteps:', maxSteps);
   }
 
   // For Ollama, dynamically set context window based on prompt size (with cap)
@@ -638,15 +639,16 @@ export async function streamCompletion(options) {
     model,
     system: options.system,
     messages: options.messages || [],
-    maxTokens: options.maxTokens || 1000,
+    maxOutputTokens: options.maxTokens || 1000,
     temperature: options.temperature ?? 0,
   };
 
   // Add tools if provided
   if (options.tools) {
+    const maxSteps = options.maxSteps || 5;
     streamOptions.tools = options.tools;
-    streamOptions.maxSteps = options.maxSteps || 5;
-    console.log('[AI Provider] Tools enabled, maxSteps:', streamOptions.maxSteps, 'tool count:', Object.keys(options.tools).length);
+    streamOptions.stopWhen = stepCountIs(maxSteps);
+    console.log('[AI Provider] Tools enabled, maxSteps:', maxSteps, 'tool count:', Object.keys(options.tools).length);
   }
 
   // Add step finish callback if provided

--- a/test/ai-provider-sdk-params.test.js
+++ b/test/ai-provider-sdk-params.test.js
@@ -1,0 +1,90 @@
+import { jest } from '@jest/globals';
+
+// These names must match what the AI SDK actually accepts. The SDK silently
+// ignores unknown options, so a rename upstream fails without any error --
+// the token cap is dropped and tool loops stop after a single step.
+const generateText = jest.fn(async () => ({ text: 'ok', steps: [] }));
+const streamText = jest.fn(() => ({ textStream: {}, fullStream: {} }));
+const stepCountIs = jest.fn(n => ({ stepCount: n }));
+
+jest.unstable_mockModule('ai', () => ({ generateText, streamText, stepCountIs, tool: jest.fn() }));
+
+jest.unstable_mockModule('../src/config.js', () => ({
+  getFullConfig: jest.fn(() => ({
+    ai: { provider: 'openai', model: 'gpt-4o', openai: { api_key: 'test-key' } },
+  })),
+  getConfig: jest.fn(),
+}));
+
+jest.unstable_mockModule('@ai-sdk/openai', () => ({
+  createOpenAI: jest.fn(() => modelName => ({ modelId: modelName })),
+}));
+
+const { createCompletion, streamCompletion, clearProviderCache } = await import('../src/ai-provider.js');
+
+const messages = [{ role: 'user', content: 'hi' }];
+const tools = { ping: { description: 'ping' } };
+
+describe('AI Provider passes SDK-supported option names', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearProviderCache();
+  });
+
+  describe('createCompletion', () => {
+    test('sends maxOutputTokens, not the legacy maxTokens', async () => {
+      await createCompletion({ messages, maxTokens: 123 });
+
+      const opts = generateText.mock.calls[0][0];
+      expect(opts.maxOutputTokens).toBe(123);
+      expect(opts).not.toHaveProperty('maxTokens');
+    });
+
+    test('defaults maxOutputTokens to 1000', async () => {
+      await createCompletion({ messages });
+
+      expect(generateText.mock.calls[0][0].maxOutputTokens).toBe(1000);
+    });
+
+    test('caps tool steps with stopWhen, not the legacy maxSteps', async () => {
+      await createCompletion({ messages, tools, maxSteps: 3 });
+
+      const opts = generateText.mock.calls[0][0];
+      expect(stepCountIs).toHaveBeenCalledWith(3);
+      expect(opts.stopWhen).toEqual({ stepCount: 3 });
+      expect(opts).not.toHaveProperty('maxSteps');
+    });
+
+    test('defaults the tool step cap to 5', async () => {
+      await createCompletion({ messages, tools });
+
+      expect(stepCountIs).toHaveBeenCalledWith(5);
+    });
+
+    test('omits stopWhen when no tools are provided', async () => {
+      await createCompletion({ messages });
+
+      expect(generateText.mock.calls[0][0]).not.toHaveProperty('stopWhen');
+      expect(stepCountIs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamCompletion', () => {
+    test('sends maxOutputTokens, not the legacy maxTokens', async () => {
+      await streamCompletion({ messages, maxTokens: 456 });
+
+      const opts = streamText.mock.calls[0][0];
+      expect(opts.maxOutputTokens).toBe(456);
+      expect(opts).not.toHaveProperty('maxTokens');
+    });
+
+    test('caps tool steps with stopWhen, not the legacy maxSteps', async () => {
+      await streamCompletion({ messages, tools, maxSteps: 2 });
+
+      const opts = streamText.mock.calls[0][0];
+      expect(stepCountIs).toHaveBeenCalledWith(2);
+      expect(opts.stopWhen).toEqual({ stepCount: 2 });
+      expect(opts).not.toHaveProperty('maxSteps');
+    });
+  });
+});


### PR DESCRIPTION
`src/ai-provider.js` was calling `generateText()`/`streamText()` with `maxTokens` and `maxSteps`. The AI SDK renamed those to `maxOutputTokens` and `stopWhen`, and it **silently ignores unknown options** — so there was no error, the settings simply never took effect.

This predates the `ai` v7 bump (#369): `ai@6` had already renamed them, so it was broken on v6 too.

## Impact

Verified with a mock language model that records what the SDK actually receives:

```
OLD (maxTokens/maxSteps)  maxOutputTokens=undefined  steps=1
NEW (fixed)               maxOutputTokens=123        steps=3
```

1. **Token cap dropped** — the model used the provider default instead of the requested limit.
2. **Tool loops never iterated** — without `stopWhen`, `generateText` runs one step: the model emits a tool call, the tool executes, but the result is never fed back. Callers asking for `maxSteps: 5` got a single round-trip.

Only the SDK-backed providers are affected (`openai`, `google`, `ollama`, `anthropic-api`). The default `anthropic` provider short-circuits to the local Claude CLI via `isCliProvider()` and never touches the SDK — likely why this went unnoticed.

## Change

Translate to the SDK's names at the call boundary only. The module's **public** option names (`options.maxTokens`, `options.maxSteps`) are deliberately unchanged — ~15 call sites across the repo pass them.

## Tests

New `test/ai-provider-sdk-params.test.js` (7 tests) pins the SDK-facing names for both `createCompletion` and `streamCompletion`, asserting `maxOutputTokens`/`stopWhen` are sent and the legacy keys are absent. Confirmed it's a real guard: **6 of the 7 fail against the pre-fix code.**

Full suite: 785 passing, 44 suites.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)