### PR TITLE
ci(security): gate npm audit on runtime dependencies only

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,20 +37,44 @@ jobs:
         id: audit
         run: |
           set +e
-          audit_output=$(npm audit --audit-level=high 2>&1)
+          # The gate covers runtime dependencies only. Dev-only advisories are
+          # reported below but do not fail the build: some are unfixable without
+          # breaking the toolchain. brace-expansion is the standing example —
+          # every version up to 5.0.7 is vulnerable, the patched 5.x line
+          # exports an object rather than a callable from `require()`, and
+          # minimatch/glob/jest all call it as a function. Overriding it breaks
+          # the test runner; not overriding it leaves an advisory that no
+          # dependency bump can clear. Gating on it blocks every PR
+          # indefinitely for a DoS in code that never ships.
+          audit_output=$(npm audit --omit=dev --audit-level=high 2>&1)
           audit_exit=$?
+
+          dev_output=$(npm audit --audit-level=high 2>&1)
+          dev_exit=$?
           set -e
 
           echo "$audit_output"
 
           {
             echo "## Security Audit Results"
+            echo ""
+            echo "### Runtime dependencies (gating)"
             if [ $audit_exit -eq 0 ]; then
               echo "No high or critical vulnerabilities found"
             else
-              echo "### Vulnerabilities Found"
               echo '```'
               echo "$audit_output"
+              echo '```'
+            fi
+
+            echo ""
+            echo "### Including dev dependencies (informational)"
+            if [ $dev_exit -eq 0 ]; then
+              echo "No high or critical vulnerabilities found"
+            else
+              echo "Not gating — see the note in \`.github/workflows/security.yml\`."
+              echo '```'
+              echo "$dev_output"
               echo '```'
             fi
           } >> $GITHUB_STEP_SUMMARY
@@ -64,7 +88,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          title="Security audit found high/critical vulnerabilities"
+          title="Security audit found high/critical vulnerabilities in runtime dependencies"
           existing=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             echo "Issue #$existing already open, skipping"


### PR DESCRIPTION
Fixes #388.

`npm audit` is a required status check and has been failing on every PR and on scheduled `main` runs, so nothing could merge without an `--admin` override — which skips *all* required checks, including the test suite.

No dependency bump can clear it. After #376, #379, #380, #382 and #386, the three remaining high-severity advisories are all dev-only:

```
$ npm ls brace-expansion --omit=dev --all
today@1.0.0
└── (empty)

$ npm ls js-yaml --omit=dev
today@1.0.0
└── js-yaml@5.2.2      # already patched

$ npm audit --omit=dev --audit-level=high; echo $?
0
```

## Why it's unfixable

`brace-expansion` is the blocker. Every version through 5.0.7 is vulnerable, and the 1.x/2.x lines `minimatch` pins have no patched release. The patched 5.x line isn't drop-in:

```
$ node -e "console.log(typeof require('brace-expansion'))"   # 5.0.9
object          # 1.x/2.x export the function itself
```

`minimatch` calls it as a function, so forcing 5.x via `overrides` breaks `minimatch` → `glob` → `jest` and `markdownlint-cli2`. `npm audit fix` takes the count from 3 highs to **19** by re-hoisting it. It can only clear when those packages move upstream.

## Change

Gate on `npm audit --omit=dev --audit-level=high`, and report the full dev-inclusive audit in the step summary as informational.

**Tradeoff, stated plainly:** dev-dependency vulnerabilities no longer block merges. That is a real reduction in enforcement. The alternative in practice has been `--admin`, which bypasses everything; this keeps tests, lint and runtime-dependency auditing enforced, and keeps dev findings visible in the summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)