### PR TITLE
fix(deps): clear high-severity runtime advisories to unblock CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -829,10 +829,12 @@
       "optional": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -4193,9 +4195,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4703,9 +4705,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5022,7 +5024,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9432,9 +9436,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
Closes #405

## Problem

`npm audit` is a required status check, and `main` currently fails it. Every open Dependabot PR fixes exactly one of three high-severity runtime advisories, so each one still trips the gate on the other two and sits at `BLOCKED`. The fixes are the thing that cannot merge.

## Change

Lockfile-only `npm audit fix --omit=dev --package-lock-only` off `main`. **`package.json` is untouched** — all five packages are transitive:

| Package | From | To | Advisory |
|---|---|---|---|
| `fast-uri` | 3.1.4 | 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) |
| `ip-address` | 10.2.0 | 10.5.0 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) + 2 |
| `undici` | 7.28.0 | 7.29.0 | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) + 4 |
| `hono` | 4.12.32 | 4.13.1 | — |
| `@hono/node-server` | 1.19.13 | 2.1.0 | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) |

`@hono/node-server` crossing a major is in-range, not forced: `@modelcontextprotocol/sdk` declares `^1.19.9 || ^2.0.5`.

## Verification

Run locally in a clean worktree off `main`:

- `npm audit --omit=dev --audit-level=high` — 5 vulnerabilities to **0**, exits 0
- `npm ci` — lockfile installs cleanly
- `npm test` — **45/45 suites pass, 797 tests green**, 1 skipped

## Follow-up

Once this lands, #395, #396, #398 and #403 should auto-close as superseded, and #400 / #401 rebase and merge on their own merits. #402 (`better-sqlite3` 12 -> 13) is unrelated and genuinely broken — the major bump fails the test suite; it needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)